### PR TITLE
Add React TypeScript frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CGE Made Simple</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "cge-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.16.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "typescript": "^5.4.0",
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+import LandingPage from './pages/LandingPage';
+import SandboxPage from './pages/SandboxPage';
+import SignupWizard from './pages/SignupWizard';
+
+const App: React.FC = () => {
+  return (
+    <Routes>
+      <Route path="/" element={<LandingPage />} />
+      <Route path="/sandbox" element={<SandboxPage />} />
+      <Route path="/signup" element={<SignupWizard />} />
+    </Routes>
+  );
+};
+
+export default App;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const LandingPage: React.FC = () => {
+  return (
+    <div>
+      <nav>
+        <div>CGE Made Simple</div>
+        <ul>
+          <li><a href="#">Home</a></li>
+          <li><a href="#">How It Works</a></li>
+          <li><a href="#">CGE Templates</a></li>
+          <li><a href="#">Pricing</a></li>
+          <li><a href="#">Support</a></li>
+        </ul>
+      </nav>
+      <div className="hero">
+        <h1>CGE Made Simple</h1>
+        <p>Watch a quick demo of a trade shock scenario.</p>
+        <video width="480" controls>
+          <source src="demo.mp4" type="video/mp4" />
+        </video>
+        <div>
+          <Link to="/sandbox"><button>Try Demo</button></Link>
+          <Link to="/signup"><button>Sign Up</button></Link>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LandingPage;

--- a/frontend/src/pages/SandboxPage.tsx
+++ b/frontend/src/pages/SandboxPage.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+
+const SandboxPage: React.FC = () => {
+  const [tariff, setTariff] = useState(0);
+  const [output, setOutput] = useState(100);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Number(e.target.value);
+    setTariff(value);
+    // Very basic effect: output decreases as tariff increases
+    setOutput(100 - value);
+  };
+
+  return (
+    <div className="container">
+      <h2>Sample Sandbox</h2>
+      <p>
+        Adjust the tariff shock and see how the model reacts.{' '}
+        <span className="tooltip" title="A Social Accounting Matrix shows economic flows between sectors.">
+          What is a SAM?
+        </span>
+      </p>
+      <label>
+        Tariff Shock (%): {tariff}
+        <input type="range" min="0" max="100" value={tariff} onChange={handleChange} />
+      </label>
+      <div className="sandbox">
+        <p>Output level: {output}</p>
+      </div>
+      <button onClick={() => alert('Issue reported')}>Report issue</button>
+    </div>
+  );
+};
+
+export default SandboxPage;

--- a/frontend/src/pages/SignupWizard.tsx
+++ b/frontend/src/pages/SignupWizard.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const steps = ['Your Name', 'Organization', 'Primary Use Case'];
+
+const SignupWizard: React.FC = () => {
+  const [step, setStep] = useState(0);
+  const [name, setName] = useState('');
+  const [organization, setOrganization] = useState('');
+  const [useCase, setUseCase] = useState('policy analysis');
+  const navigate = useNavigate();
+
+  const progress = ((step + 1) / steps.length) * 100;
+
+  const next = () => {
+    if (step < steps.length - 1) {
+      setStep(step + 1);
+    } else {
+      alert(`Name: ${name}\nOrg: ${organization}\nUse Case: ${useCase}`);
+      navigate('/');
+    }
+  };
+
+  const skip = () => navigate('/');
+
+  return (
+    <div className="container wizard">
+      <h2>Sign Up</h2>
+      <div className="progress">
+        <div className="progress-bar" style={{ width: `${progress}%` }} />
+      </div>
+      {step === 0 && (
+        <div>
+          <label>
+            Name:
+            <input value={name} onChange={(e) => setName(e.target.value)} />
+          </label>
+        </div>
+      )}
+      {step === 1 && (
+        <div>
+          <label>
+            Organization:
+            <input value={organization} onChange={(e) => setOrganization(e.target.value)} />
+          </label>
+        </div>
+      )}
+      {step === 2 && (
+        <div>
+          <label>
+            Primary Use Case:
+            <select value={useCase} onChange={(e) => setUseCase(e.target.value)}>
+              <option value="policy analysis">Policy Analysis</option>
+              <option value="academic research">Academic Research</option>
+              <option value="private sector">Private Sector</option>
+            </select>
+          </label>
+        </div>
+      )}
+      <div className="wizard-nav">
+        <button onClick={next}>{step === steps.length - 1 ? 'Finish' : 'Next'}</button>
+        <button onClick={skip}>Skip for now</button>
+      </div>
+    </div>
+  );
+};
+
+export default SignupWizard;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,75 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+nav {
+  background-color: #003366;
+  color: white;
+  padding: 10px 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+nav ul {
+  list-style: none;
+  display: flex;
+  gap: 15px;
+  margin: 0;
+  padding: 0;
+}
+
+nav a {
+  color: white;
+  text-decoration: none;
+}
+
+.container {
+  padding: 20px;
+}
+
+.hero {
+  text-align: center;
+  padding: 40px 20px;
+}
+
+.hero button {
+  margin: 10px;
+  padding: 10px 20px;
+  font-size: 16px;
+}
+
+.sandbox {
+  margin-top: 20px;
+}
+
+.tooltip {
+  border-bottom: 1px dotted #000;
+  cursor: help;
+}
+
+.wizard {
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.progress {
+  height: 5px;
+  background-color: #ccc;
+  margin-bottom: 20px;
+  position: relative;
+}
+
+.progress-bar {
+  height: 5px;
+  background-color: #003366;
+  width: 0%;
+  transition: width 0.3s;
+}
+
+.wizard-nav {
+  text-align: right;
+  margin-top: 10px;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- set up a basic React + Vite project in `frontend`
- implement landing, sandbox demo, and sign‑up wizard pages
- include simple styles and routing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685feff232c0832a952082674bcf2cfe