### PR TITLE
Fix port references

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ pip install -r requirements.txt
 python app.py
 ```
 
-The application will be available at http://localhost:3000, with the backend API running at http://localhost:5000.
+The application will be available at http://localhost:3000, with the backend API running at http://localhost:5001.
 
 ## Available CGE Models
 

--- a/backend/test_sam.py
+++ b/backend/test_sam.py
@@ -7,7 +7,7 @@ import requests
 
 def test_generate_sam():
     """Test the generate-random-sam endpoint"""
-    url = "http://localhost:5000/generate-random-sam"
+    url = "http://localhost:5001/generate-random-sam"
     
     # Test with standard dimensions
     payload = {
@@ -73,7 +73,7 @@ def test_generate_sam():
 
 def test_solve_model(sam=None):
     """Test the solve-model endpoint"""
-    url = "http://localhost:5000/solve-model"
+    url = "http://localhost:5001/solve-model"
     
     if sam:
         print("\nTesting model solving with custom SAM...")
@@ -134,7 +134,7 @@ def test_solve_model(sam=None):
 
 def test_compare_scenarios(sam=None):
     """Test the compare-scenarios endpoint"""
-    url = "http://localhost:5000/compare-scenarios"
+    url = "http://localhost:5001/compare-scenarios"
     
     if sam:
         print("\nTesting scenario comparison with custom SAM...")

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:5000',
+        target: 'http://localhost:5001',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, '')
       }


### PR DESCRIPTION
## Summary
- update README to point to backend on port 5001
- update vite proxy config to match port 5001
- adjust backend test script URLS to port 5001

## Testing
- `python backend/test_sam.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6861071ea63c832a88bfacddac14da36