### PR TITLE
Add test page with AG Grid

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import Navbar from './components/Navbar';
 import Footer from './components/Footer';
 import HomePage from './screens/HomePage';
 import ModelBuilderPage from './screens/ModelBuilderPage';
+import TableTestPage from './screens/TableTestPage';
 import './styles/index.css';
 
 const App = () => {
@@ -14,6 +15,7 @@ const App = () => {
           <Routes>
             <Route path="/" element={<HomePage />} />
             <Route path="/model-builder" element={<ModelBuilderPage />} />
+            <Route path="/table-test" element={<TableTestPage />} />
           </Routes>
         </main>
         <Footer />

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -34,6 +34,16 @@ const Navbar = () => {
               >
                 Model Builder
               </Link>
+              <Link
+                to="/table-test"
+                className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
+                  location.pathname === '/table-test'
+                    ? 'border-primary text-darkgray'
+                    : 'border-transparent text-midgray hover:text-darkgray'
+                }`}
+              >
+                Table Test
+              </Link>
             </div>
           </div>
         </div>

--- a/frontend/src/components/SAMTable.tsx
+++ b/frontend/src/components/SAMTable.tsx
@@ -187,7 +187,9 @@ const SAMTable = ({ sam, onChange, readOnly = false }: SAMTableProps) => {
 
   return (
     <div className="w-full">
-      <div className="ag-theme-alpine w-full" style={{ height: '60vh', border: '1px solid #ddd' }}>
+      <div
+        className="ag-theme-alpine w-full h-[60vh] border border-midgray"
+      >
         {!sam || !sam.entries || sam.entries.length === 0 ? (
           <div className="flex flex-col h-full">
             <div className="flex-grow flex items-center justify-center bg-neutral/50 border border-midgray/30 rounded-md">
@@ -204,6 +206,7 @@ const SAMTable = ({ sam, onChange, readOnly = false }: SAMTableProps) => {
              4. Added key based on entries length to force re-render
           */
           <AgGridReact
+            className="w-full h-full"
             key={`sam-grid-${sam.entries.length}`}
             columnDefs={columnDefs}
             rowData={rowData}

--- a/frontend/src/screens/TableTestPage.tsx
+++ b/frontend/src/screens/TableTestPage.tsx
@@ -1,0 +1,50 @@
+import { useMemo } from 'react';
+import { AgGridReact } from 'ag-grid-react';
+import 'ag-grid-community/styles/ag-grid.css';
+import 'ag-grid-community/styles/ag-theme-alpine.css';
+
+const TableTestPage = () => {
+  const entries = ['A', 'B', 'C', 'D', 'E'];
+
+  const columnDefs = useMemo(
+    () => [
+      { headerName: '', field: 'entryName', editable: false, width: 120 },
+      ...entries.map((entry, index) => ({
+        headerName: entry,
+        field: `cell${index}`,
+        editable: true,
+        width: 100
+      }))
+    ],
+    []
+  );
+
+  const rowData = useMemo(() => {
+    return entries.map((entry, rowIndex) => {
+      const row: any = { entryName: entry };
+      entries.forEach((_, colIndex) => {
+        row[`cell${colIndex}`] = `${rowIndex},${colIndex}`;
+      });
+      return row;
+    });
+  }, []);
+
+  return (
+    <div className="max-w-7xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">AG Grid Test</h1>
+      <div className="ag-theme-alpine w-full h-[60vh] border border-midgray">
+        <AgGridReact
+          className="w-full h-full"
+          columnDefs={columnDefs}
+          rowData={rowData}
+          defaultColDef={{ resizable: true, sortable: false, editable: true }}
+          domLayout="normal"
+          immutableData={false}
+          rowHeight={40}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default TableTestPage;


### PR DESCRIPTION
## Summary
- add `TableTestPage` with a simple 5x5 AG Grid table
- expose new test page via router
- link the page from the navbar

## Testing
- `npm run lint` *(fails: ESLint couldn't find the plugin)*
- `npm run build` *(fails: cannot find dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6861121b45dc832ab8d06443dda4dbff