### PR TITLE
Remove ag-grid height override

### DIFF
--- a/frontend/src/screens/TableTestPage.tsx
+++ b/frontend/src/screens/TableTestPage.tsx
@@ -34,6 +34,9 @@ const TableTestPage = () => {
       <h1 className="text-2xl font-bold mb-4">AG Grid Test</h1>
       <div className="ag-theme-alpine w-full h-[60vh] border border-midgray">
         <AgGridReact
+          /* Ensure grid re-renders correctly by using a key based on the
+             number of entries */
+          key={`test-grid-${entries.length}`}
           className="w-full h-full"
           columnDefs={columnDefs}
           rowData={rowData}

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -63,6 +63,5 @@
     /* Force display */
     display: block !important;
     width: 100% !important;
-    height: 100% !important;
   }
 }


### PR DESCRIPTION
## Summary
- fix AG Grid styling to avoid overriding container height
- ensure test grid re-renders by adding key

## Testing
- `npm run build` *(fails: Cannot find module 'axios' and other packages)*

------
https://chatgpt.com/codex/tasks/task_e_68611bfe2e94832aa7ec0fc8cfefbf56