### PR TITLE
Fix infinite state loop in ParameterInputs

### DIFF
--- a/frontend/src/components/ParameterInputs.tsx
+++ b/frontend/src/components/ParameterInputs.tsx
@@ -24,25 +24,35 @@ const ParameterInputs = ({ initialParams, sam, onChange }: ParameterInputsProps)
   useEffect(() => {
     if (sam.goods.length > 0) {
       // Initialize alpha values (utility function coefficients for each good)
-      const defaultAlpha = sam.goods.map((_, index) => 
-        initialParams?.alpha?.[index] !== undefined 
+      const defaultAlpha = sam.goods.map((_, index) =>
+        initialParams?.alpha?.[index] !== undefined
           ? initialParams.alpha[index]
           : 1 / sam.goods.length
       );
-      setAlphaValues(defaultAlpha);
-      
+
       // Initialize b values (production function scale parameters)
-      const defaultB = sam.goods.map((_, index) => 
+      const defaultB = sam.goods.map((_, index) =>
         initialParams?.b?.[index] !== undefined
           ? initialParams.b[index]
           : 1.0
       );
-      setBValues(defaultB);
-      
-      console.log('ParameterInputs - Initial values:', {
-        alpha: defaultAlpha,
-        b: defaultB
-      });
+
+      const alphaChanged =
+        defaultAlpha.length !== alphaValues.length ||
+        defaultAlpha.some((v, i) => v !== alphaValues[i]);
+      const bChanged =
+        defaultB.length !== bValues.length ||
+        defaultB.some((v, i) => v !== bValues[i]);
+
+      if (alphaChanged) setAlphaValues(defaultAlpha);
+      if (bChanged) setBValues(defaultB);
+
+      if (alphaChanged || bChanged) {
+        console.log('ParameterInputs - Initial values:', {
+          alpha: defaultAlpha,
+          b: defaultB
+        });
+      }
     }
   }, [sam.goods.length, initialParams]);
 


### PR DESCRIPTION
## Summary
- avoid resetting ParameterInputs state when values haven't changed to prevent `Maximum update depth exceeded` errors

## Testing
- `npm run lint` *(fails: ESLint couldn't find plugin eslint-plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_686400c7c034832a9c3a65aca6db9f33