### PR TITLE
Add login/signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Future versions will add:
 - Parameter input forms
 - Results visualization with charts
 - Scenario comparison dashboard
+- Basic user authentication with login and signup pages
 
 ## License
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -4,6 +4,8 @@ import numpy as np
 import json
 import random
 import traceback
+import sqlite3
+from werkzeug.security import generate_password_hash, check_password_hash
 from models.splcge import add_input_solve
 from models.dynamic_splcge import dynamic_solve, extract_results
 from sam_utils.generator import generate_random_sam as gen_sam
@@ -18,6 +20,29 @@ from utils.validators import (
 app = Flask(__name__)
 # Enable CORS for all routes and all origins
 CORS(app, resources={r"/*": {"origins": "*"}})
+
+
+def get_db_connection():
+    conn = sqlite3.connect('users.db')
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db():
+    with get_db_connection() as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT UNIQUE NOT NULL,
+                password TEXT NOT NULL
+            )
+            """
+        )
+        conn.commit()
+
+
+init_db()
 
 @app.route('/solve-model', methods=['POST'])
 def solve_model():
@@ -179,6 +204,49 @@ def solve_model():
             'trace': stack_trace,
             'details': 'There was an unexpected error processing your request.'
         }), 500
+
+
+@app.route('/register', methods=['POST'])
+def register():
+    if not request.is_json:
+        return jsonify({'error': 'Request must be JSON'}), 400
+    data = request.get_json()
+    username = data.get('username')
+    password = data.get('password')
+    if not username or not password:
+        return jsonify({'error': 'Username and password required'}), 400
+    try:
+        with get_db_connection() as conn:
+            conn.execute(
+                'INSERT INTO users (username, password) VALUES (?, ?)',
+                (username, generate_password_hash(password))
+            )
+            conn.commit()
+        return jsonify({'message': 'User registered successfully'})
+    except sqlite3.IntegrityError:
+        return jsonify({'error': 'Username already exists'}), 400
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+
+@app.route('/login', methods=['POST'])
+def login():
+    if not request.is_json:
+        return jsonify({'error': 'Request must be JSON'}), 400
+    data = request.get_json()
+    username = data.get('username')
+    password = data.get('password')
+    if not username or not password:
+        return jsonify({'error': 'Username and password required'}), 400
+    try:
+        with get_db_connection() as conn:
+            cur = conn.execute('SELECT password FROM users WHERE username=?', (username,))
+            row = cur.fetchone()
+        if row and check_password_hash(row['password'], password):
+            return jsonify({'message': 'Login successful'})
+        return jsonify({'error': 'Invalid credentials'}), 401
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
 
 @app.route('/compare-scenarios', methods=['POST'])
 def compare_scenarios():

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,8 @@ import Footer from './components/Footer';
 import HomePage from './screens/HomePage';
 import ModelBuilderPage from './screens/ModelBuilderPage';
 import TableTestPage from './screens/TableTestPage';
+import LoginPage from './screens/LoginPage';
+import SignupPage from './screens/SignupPage';
 import './styles/index.css';
 
 const App = () => {
@@ -16,6 +18,8 @@ const App = () => {
             <Route path="/" element={<HomePage />} />
             <Route path="/model-builder" element={<ModelBuilderPage />} />
             <Route path="/table-test" element={<TableTestPage />} />
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/signup" element={<SignupPage />} />
           </Routes>
         </main>
         <Footer />

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -44,6 +44,16 @@ const Navbar = () => {
               >
                 Table Test
               </Link>
+              <Link
+                to="/login"
+                className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
+                  location.pathname === '/login'
+                    ? 'border-primary text-darkgray'
+                    : 'border-transparent text-midgray hover:text-darkgray'
+                }`}
+              >
+                Login
+              </Link>
             </div>
           </div>
         </div>

--- a/frontend/src/screens/LoginPage.tsx
+++ b/frontend/src/screens/LoginPage.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import { loginUser } from '../utils/api';
+import { Link, useNavigate } from 'react-router-dom';
+
+const LoginPage = () => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await loginUser(username, password);
+      navigate('/');
+    } catch (err: any) {
+      setError(err?.error || 'Login failed');
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto my-12 card">
+      <h2 className="text-2xl font-bold text-center mb-6">Login</h2>
+      {error && <p className="text-warning mb-4 text-center">{error}</p>}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="text"
+          className="input w-full"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <input
+          type="password"
+          className="input w-full"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button type="submit" className="btn btn-primary w-full">
+          Login
+        </button>
+      </form>
+      <p className="text-sm text-center mt-4">
+        Don't have an account?{' '}
+        <Link to="/signup" className="text-primary hover:underline">
+          Sign up
+        </Link>
+      </p>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/frontend/src/screens/SignupPage.tsx
+++ b/frontend/src/screens/SignupPage.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import { registerUser } from '../utils/api';
+import { Link, useNavigate } from 'react-router-dom';
+
+const SignupPage = () => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await registerUser(username, password);
+      navigate('/login');
+    } catch (err: any) {
+      setError(err?.error || 'Signup failed');
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto my-12 card">
+      <h2 className="text-2xl font-bold text-center mb-6">Sign Up</h2>
+      {error && <p className="text-warning mb-4 text-center">{error}</p>}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="text"
+          className="input w-full"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <input
+          type="password"
+          className="input w-full"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button type="submit" className="btn btn-primary w-full">
+          Sign Up
+        </button>
+      </form>
+      <p className="text-sm text-center mt-4">
+        Already have an account?{' '}
+        <Link to="/login" className="text-primary hover:underline">
+          Login
+        </Link>
+      </p>
+    </div>
+  );
+};
+
+export default SignupPage;

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -108,4 +108,14 @@ export const generateRandomSam = async (
   }
 };
 
+export const registerUser = async (username: string, password: string) => {
+  const response = await api.post('/register', { username, password });
+  return response.data;
+};
+
+export const loginUser = async (username: string, password: string) => {
+  const response = await api.post('/login', { username, password });
+  return response.data;
+};
+
 export default api;


### PR DESCRIPTION
## Summary
- create SQLite user table and add /register + /login routes
- add Login and Signup screens and navigation
- expose login/signup API helpers
- document authentication in README

## Testing
- `python -m py_compile backend/app.py`
- `npm run build` *(fails: Cannot find module 'react' and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68643b6f700c832a9f5b0759cd05bc12