### PR TITLE
Add show password and error popup to login

### DIFF
--- a/frontend/src/screens/LoginPage.tsx
+++ b/frontend/src/screens/LoginPage.tsx
@@ -5,7 +5,9 @@ import { Link, useNavigate } from 'react-router-dom';
 const LoginPage = () => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [showPopup, setShowPopup] = useState(false);
   const navigate = useNavigate();
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -14,40 +16,65 @@ const LoginPage = () => {
       await loginUser(username, password);
       navigate('/');
     } catch (err: any) {
-      setError(err?.error || 'Login failed');
+      setError(err?.error || 'Incorrect username or password.');
+      setShowPopup(true);
     }
   };
 
   return (
-    <div className="max-w-md mx-auto my-12 card">
-      <h2 className="text-2xl font-bold text-center mb-6">Login</h2>
-      {error && <p className="text-warning mb-4 text-center">{error}</p>}
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <input
-          type="text"
-          className="input w-full"
-          placeholder="Username"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-        />
-        <input
-          type="password"
-          className="input w-full"
-          placeholder="Password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        <button type="submit" className="btn btn-primary w-full">
-          Login
-        </button>
-      </form>
-      <p className="text-sm text-center mt-4">
-        Don't have an account?{' '}
-        <Link to="/signup" className="text-primary hover:underline">
-          Sign up
-        </Link>
-      </p>
-    </div>
+    <>
+      {showPopup && error && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg shadow-md p-6 max-w-sm w-full">
+            <p className="mb-4 text-center text-warning">{error}</p>
+            <button
+              type="button"
+              className="btn btn-primary w-full"
+              onClick={() => setShowPopup(false)}
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+      <div className="max-w-md mx-auto my-12 card">
+        <h2 className="text-2xl font-bold text-center mb-6">Login</h2>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="text"
+            className="input w-full"
+            placeholder="Username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+          <div className="relative">
+            <input
+              type={showPassword ? 'text' : 'password'}
+              className="input w-full pr-16"
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+            <button
+              type="button"
+              className="absolute inset-y-0 right-0 px-3 text-sm text-darkgray/60"
+              onClick={() => setShowPassword(!showPassword)}
+            >
+              {showPassword ? 'Hide' : 'Show'}
+            </button>
+          </div>
+          <button type="submit" className="btn btn-primary w-full">
+            Login
+          </button>
+        </form>
+        <p className="text-sm text-center mt-4">
+          Don't have an account?{' '}
+          <Link to="/signup" className="text-primary hover:underline">
+            Sign up
+          </Link>
+        </p>
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- add password visibility toggle on login page
- display login errors in popup instead of inline message

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68643fb50364832a8dd884e80bbc50fb