### PR TITLE
Add basic auth state

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,7 +1,10 @@
 import { Link, useLocation } from 'react-router-dom';
+import { useContext } from 'react';
+import { AuthContext } from '../contexts/AuthContext';
 
 const Navbar = () => {
   const location = useLocation();
+  const { username, logout } = useContext(AuthContext);
   
   return (
     <nav className="bg-white shadow-sm">
@@ -13,48 +16,78 @@ const Navbar = () => {
                 CGE Model Builder
               </Link>
             </div>
-            <div className="hidden sm:ml-6 sm:flex sm:space-x-8">
-              <Link
-                to="/"
-                className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
-                  location.pathname === '/'
-                    ? 'border-primary text-darkgray'
-                    : 'border-transparent text-midgray hover:text-darkgray'
-                }`}
-              >
-                Home
-              </Link>
-              <Link
-                to="/model-builder"
-                className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
-                  location.pathname === '/model-builder'
-                    ? 'border-primary text-darkgray'
-                    : 'border-transparent text-midgray hover:text-darkgray'
-                }`}
-              >
-                Model Builder
-              </Link>
-              <Link
-                to="/table-test"
-                className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
-                  location.pathname === '/table-test'
-                    ? 'border-primary text-darkgray'
-                    : 'border-transparent text-midgray hover:text-darkgray'
-                }`}
-              >
-                Table Test
-              </Link>
-              <Link
-                to="/login"
-                className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
-                  location.pathname === '/login'
-                    ? 'border-primary text-darkgray'
-                    : 'border-transparent text-midgray hover:text-darkgray'
-                }`}
-              >
-                Login
-              </Link>
-            </div>
+            {username && (
+              <div className="hidden sm:ml-6 sm:flex sm:space-x-8">
+                <Link
+                  to="/"
+                  className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
+                    location.pathname === '/'
+                      ? 'border-primary text-darkgray'
+                      : 'border-transparent text-midgray hover:text-darkgray'
+                  }`}
+                >
+                  Home
+                </Link>
+                <Link
+                  to="/model-builder"
+                  className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
+                    location.pathname === '/model-builder'
+                      ? 'border-primary text-darkgray'
+                      : 'border-transparent text-midgray hover:text-darkgray'
+                  }`}
+                >
+                  Model Builder
+                </Link>
+                <Link
+                  to="/table-test"
+                  className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
+                    location.pathname === '/table-test'
+                      ? 'border-primary text-darkgray'
+                      : 'border-transparent text-midgray hover:text-darkgray'
+                  }`}
+                >
+                  Table Test
+                </Link>
+              </div>
+            )}
+          </div>
+          <div className="flex items-center">
+            {username ? (
+              <div className="relative group">
+                <span className="font-bold cursor-pointer">{username}</span>
+                <div className="absolute right-0 mt-2 w-24 bg-white border rounded shadow-lg hidden group-hover:block">
+                  <button
+                    onClick={logout}
+                    className="block w-full text-left px-4 py-2 text-sm hover:bg-gray-100"
+                  >
+                    Log out
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="flex space-x-4">
+                <Link
+                  to="/login"
+                  className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
+                    location.pathname === '/login'
+                      ? 'border-primary text-darkgray'
+                      : 'border-transparent text-midgray hover:text-darkgray'
+                  }`}
+                >
+                  Log in
+                </Link>
+                <Link
+                  to="/signup"
+                  className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
+                    location.pathname === '/signup'
+                      ? 'border-primary text-darkgray'
+                      : 'border-transparent text-midgray hover:text-darkgray'
+                  }`}
+                >
+                  Sign up
+                </Link>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,0 +1,40 @@
+import { createContext, useEffect, useState, ReactNode } from 'react';
+
+interface AuthContextProps {
+  username: string | null;
+  login: (name: string) => void;
+  logout: () => void;
+}
+
+export const AuthContext = createContext<AuthContextProps>({
+  username: null,
+  login: () => {},
+  logout: () => {},
+});
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [username, setUsername] = useState<string | null>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('username');
+    if (stored) {
+      setUsername(stored);
+    }
+  }, []);
+
+  const login = (name: string) => {
+    localStorage.setItem('username', name);
+    setUsername(name);
+  };
+
+  const logout = () => {
+    localStorage.removeItem('username');
+    setUsername(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ username, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { AuthProvider } from './contexts/AuthContext';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </React.StrictMode>,
 );

--- a/frontend/src/screens/HomePage.tsx
+++ b/frontend/src/screens/HomePage.tsx
@@ -1,6 +1,9 @@
 import { Link } from 'react-router-dom';
+import { useContext } from 'react';
+import { AuthContext } from '../contexts/AuthContext';
 
 const HomePage = () => {
+  const { username } = useContext(AuthContext);
   const features = [
     {
       icon: '📊',
@@ -35,10 +38,10 @@ const HomePage = () => {
           Empower decision-making with economic simulations. No math required.
         </p>
         <Link
-          to="/model-builder"
+          to={username ? '/model-builder' : '/signup'}
           className="btn btn-primary text-lg py-3 px-8"
         >
-          Build Your Model
+          {username ? 'Build Your Model' : 'Get Started'}
         </Link>
       </div>
 

--- a/frontend/src/screens/LoginPage.tsx
+++ b/frontend/src/screens/LoginPage.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useState, useContext } from 'react';
 import { loginUser } from '../utils/api';
 import { Link, useNavigate } from 'react-router-dom';
+import { AuthContext } from '../contexts/AuthContext';
 
 const LoginPage = () => {
   const [username, setUsername] = useState('');
@@ -8,11 +9,13 @@ const LoginPage = () => {
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
+  const { login } = useContext(AuthContext);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
       await loginUser(username, password);
+      login(username);
       navigate('/');
     } catch (err: any) {
       setError(err?.error || 'Incorrect username or password.');


### PR DESCRIPTION
## Summary
- manage username via context provider
- show navbar links only for logged in users
- add dropdown logout option
- adapt landing page button to sign up or start modeling
- persist login via local storage

## Testing
- `npm run lint` *(fails: ESLint couldn't find the plugin 'eslint-plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_686446b709b0832a98ad6f09a07d6343