### PR TITLE
Add blog, about and contact pages

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -5,6 +5,9 @@ import json
 import random
 import traceback
 import sqlite3
+import os
+import smtplib
+from email.message import EmailMessage
 from werkzeug.security import generate_password_hash, check_password_hash
 from models.splcge import add_input_solve
 from models.dynamic_splcge import dynamic_solve, extract_results
@@ -43,6 +46,30 @@ def init_db():
 
 
 init_db()
+
+
+def send_contact_email(name: str, email: str, message: str):
+    smtp_server = os.environ.get('SMTP_SERVER', 'localhost')
+    smtp_port = int(os.environ.get('SMTP_PORT', 25))
+    smtp_user = os.environ.get('SMTP_USERNAME')
+    smtp_password = os.environ.get('SMTP_PASSWORD')
+
+    msg = EmailMessage()
+    msg['Subject'] = 'New Contact Form Submission'
+    msg['From'] = email if not smtp_user else smtp_user
+    msg['To'] = 'aalqershi@kaizen.sa'
+    msg.set_content(f"Name: {name}\nEmail: {email}\n\n{message}")
+
+    try:
+        with smtplib.SMTP(smtp_server, smtp_port) as server:
+            if smtp_user and smtp_password:
+                server.starttls()
+                server.login(smtp_user, smtp_password)
+            server.send_message(msg)
+        return True, 'Message sent'
+    except Exception as e:
+        print(f'Error sending email: {e}')
+        return False, str(e)
 
 @app.route('/solve-model', methods=['POST'])
 def solve_model():
@@ -692,6 +719,23 @@ def generate_random_sam():
             'trace': stack_trace,
             'details': 'There was an unexpected error processing your request.'
         }), 500
+
+
+@app.route('/contact', methods=['POST'])
+def contact():
+    if not request.is_json:
+        return jsonify({'error': 'Request must be JSON'}), 400
+    data = request.get_json()
+    name = data.get('name')
+    email = data.get('email')
+    message = data.get('message')
+    if not name or not email or not message:
+        return jsonify({'error': 'Name, email and message are required'}), 400
+
+    success, info = send_contact_email(name, email, message)
+    if success:
+        return jsonify({'message': 'Message sent'})
+    return jsonify({'error': info}), 500
 
 # Add a simple test route
 @app.route('/', methods=['GET'])

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,9 @@ import HomePage from './screens/HomePage';
 import ModelBuilderPage from './screens/ModelBuilderPage';
 import LoginPage from './screens/LoginPage';
 import SignupPage from './screens/SignupPage';
+import AboutPage from './screens/AboutPage';
+import BlogPage from './screens/BlogPage';
+import ContactPage from './screens/ContactPage';
 import './styles/index.css';
 
 const App = () => {
@@ -15,6 +18,9 @@ const App = () => {
         <main className="flex-grow">
           <Routes>
             <Route path="/" element={<HomePage />} />
+            <Route path="/blog" element={<BlogPage />} />
+            <Route path="/about" element={<AboutPage />} />
+            <Route path="/contact" element={<ContactPage />} />
             <Route path="/model-builder" element={<ModelBuilderPage />} />
             <Route path="/login" element={<LoginPage />} />
             <Route path="/signup" element={<SignupPage />} />

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -10,18 +10,18 @@ const Footer = () => {
             <div className="mt-4 md:mt-0">
               <ul className="flex space-x-6">
                 <li>
-                  <a href="#" className="text-sm text-darkgray/70 hover:text-primary">
+                  <a href="/about" className="text-sm text-darkgray/70 hover:text-primary">
                     About
                   </a>
                 </li>
                 <li>
-                  <a href="#" className="text-sm text-darkgray/70 hover:text-primary">
-                    Contact
+                  <a href="/blog" className="text-sm text-darkgray/70 hover:text-primary">
+                    Blog
                   </a>
                 </li>
                 <li>
-                  <a href="#" className="text-sm text-darkgray/70 hover:text-primary">
-                    Terms
+                  <a href="/contact" className="text-sm text-darkgray/70 hover:text-primary">
+                    Contact
                   </a>
                 </li>
               </ul>

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -24,18 +24,48 @@ const Navbar = () => {
                 CGE Model Builder
               </Link>
             </div>
-            {username && (
-              <div className="hidden sm:ml-6 sm:flex sm:space-x-8">
-                <Link
-                  to="/"
-                  className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
-                    location.pathname === '/'
-                      ? 'border-primary text-darkgray'
-                      : 'border-transparent text-midgray hover:text-darkgray'
-                  }`}
-                >
-                  Home
-                </Link>
+            <div className="hidden sm:ml-6 sm:flex sm:space-x-8">
+              <Link
+                to="/"
+                className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
+                  location.pathname === '/'
+                    ? 'border-primary text-darkgray'
+                    : 'border-transparent text-midgray hover:text-darkgray'
+                }`}
+              >
+                Home
+              </Link>
+              <Link
+                to="/blog"
+                className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
+                  location.pathname === '/blog'
+                    ? 'border-primary text-darkgray'
+                    : 'border-transparent text-midgray hover:text-darkgray'
+                }`}
+              >
+                Blog
+              </Link>
+              <Link
+                to="/about"
+                className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
+                  location.pathname === '/about'
+                    ? 'border-primary text-darkgray'
+                    : 'border-transparent text-midgray hover:text-darkgray'
+                }`}
+              >
+                About
+              </Link>
+              <Link
+                to="/contact"
+                className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
+                  location.pathname === '/contact'
+                    ? 'border-primary text-darkgray'
+                    : 'border-transparent text-midgray hover:text-darkgray'
+                }`}
+              >
+                Contact
+              </Link>
+              {username && (
                 <Link
                   to="/model-builder"
                   className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
@@ -46,8 +76,8 @@ const Navbar = () => {
                 >
                   Model Builder
                 </Link>
-              </div>
-            )}
+              )}
+            </div>
           </div>
           <div className="flex items-center">
             {username ? (

--- a/frontend/src/screens/AboutPage.tsx
+++ b/frontend/src/screens/AboutPage.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+const AboutPage = () => {
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8 space-y-12">
+      <div className="space-y-4 animate-fadeInUp">
+        <h1 className="text-3xl font-bold">About Us</h1>
+        <p className="text-darkgray/80">
+          Kaizen is a pioneering platform dedicated to making complex economic modeling accessible
+          through intuitive interfaces and powerful visualizations. We believe that economic insights
+          should be available to everyone, not just technical specialists.
+        </p>
+      </div>
+      <section className="space-y-4 animate-fadeInUp">
+        <h2 className="text-2xl font-bold">Our Mission</h2>
+        <p>
+          Our mission is to democratize access to economic modeling tools by creating
+          user-friendly interfaces for Computable General Equilibrium (CGE) models that
+          provide valuable insights for policymakers, researchers, and educational institutions.
+        </p>
+      </section>
+      <section className="space-y-6 animate-fadeInUp">
+        <h2 className="text-2xl font-bold">Our Team</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
+          <div className="card text-center space-y-2">
+            <img src="https://via.placeholder.com/150" alt="Dr. Ibrahim Aljarrah" className="w-full" />
+            <h3>Dr. Ibrahim Aljarrah</h3>
+            <p className="text-sm">Founder &amp; Lead Economist</p>
+            <p className="text-sm">PhD in Economic Modeling with 15+ years of experience in CGE model development.</p>
+          </div>
+          <div className="card text-center space-y-2">
+            <img src="https://via.placeholder.com/150" alt="Almaen Salah" className="w-full" />
+            <h3>Almaen Salah</h3>
+            <p className="text-sm">Chief Technology Officer</p>
+            <p className="text-sm">Expert in computational methods and visualization of economic data.</p>
+          </div>
+          <div className="card text-center space-y-2">
+            <img src="https://via.placeholder.com/150" alt="Ahmed Alqershi" className="w-full" />
+            <h3>Ahmed Alqershi</h3>
+            <p className="text-sm">Lead Developer</p>
+            <p className="text-sm">Specializes in creating interactive web applications for complex data.</p>
+          </div>
+        </div>
+      </section>
+      <section className="space-y-4 animate-fadeInUp">
+        <h2 className="text-2xl font-bold">Our Partners</h2>
+        <p>We collaborate with leading research institutions, universities, and government agencies.</p>
+      </section>
+      <section className="space-y-4 animate-fadeInUp">
+        <h2 className="text-2xl font-bold">Contact Us</h2>
+        <p>Email: <a className="text-primary" href="mailto:aalqershi@kaizen.sa">aalqershi@kaizen.sa</a></p>
+        <p>Phone: +90 (553) 919 09 67</p>
+        <p>Address: ...</p>
+      </section>
+    </div>
+  );
+};
+
+export default AboutPage;

--- a/frontend/src/screens/BlogPage.tsx
+++ b/frontend/src/screens/BlogPage.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+const BlogPage = () => {
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8 space-y-12">
+      <section className="space-y-4 animate-fadeInUp">
+        <h1 className="text-3xl font-bold">Computable General Equilibrium</h1>
+        <p className="text-darkgray/80">
+          Computable General Equilibrium (CGE) models are powerful tools used to capture the complex interactions
+          within an economy. They consider how households, firms and governments respond to policy changes
+          and external shocks, providing valuable insights for decision makers.
+        </p>
+      </section>
+      <section className="space-y-4 animate-fadeInUp bg-neutral rounded-lg p-6 shadow">
+        <h2 className="text-2xl font-bold">Why CGE Models?</h2>
+        <p>
+          CGE models ensure that supply equals demand across all markets while accounting for behavioral responses.
+          They are frequently used for trade policy analysis, tax reform evaluation and forecasting economic growth.
+        </p>
+      </section>
+      <section className="space-y-4 animate-fadeInUp">
+        <h2 className="text-2xl font-bold">Applications</h2>
+        <ul className="list-disc pl-6 space-y-2">
+          <li>Assessing the impact of new tax policies on households and firms.</li>
+          <li>Evaluating trade agreements and tariffs.</li>
+          <li>Analyzing environmental regulations and climate policies.</li>
+        </ul>
+      </section>
+    </div>
+  );
+};
+
+export default BlogPage;

--- a/frontend/src/screens/ContactPage.tsx
+++ b/frontend/src/screens/ContactPage.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import { sendContactMessage } from '../utils/api';
+
+const ContactPage = () => {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [sent, setSent] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await sendContactMessage(name, email, message);
+      setSent(true);
+      setName('');
+      setEmail('');
+      setMessage('');
+    } catch (err: any) {
+      setError(err?.error || 'Unable to send message');
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto my-12 card animate-fadeInUp">
+      {sent ? (
+        <p className="text-center text-success font-semibold">
+          We received your message and we will get back to you shortly.
+        </p>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <h1 className="text-2xl font-bold text-center">Contact Us</h1>
+          {error && <p className="text-red-600 text-center">{error}</p>}
+          <input
+            className="input w-full"
+            placeholder="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <input
+            className="input w-full"
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <textarea
+            className="input w-full h-32"
+            placeholder="Message"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+          />
+          <button type="submit" className="btn btn-primary w-full">
+            Send
+          </button>
+        </form>
+      )}
+    </div>
+  );
+};
+
+export default ContactPage;

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -108,6 +108,15 @@ export const generateRandomSam = async (
   }
 };
 
+export const sendContactMessage = async (
+  name: string,
+  email: string,
+  message: string
+) => {
+  const response = await api.post('/contact', { name, email, message });
+  return response.data;
+};
+
 export const registerUser = async (username: string, password: string) => {
   const response = await api.post('/register', { username, password });
   return response.data;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -15,6 +15,15 @@ export default {
         success: "#10b981",
         warning: "#f59e0b",
       },
+      keyframes: {
+        fadeInUp: {
+          '0%': { opacity: '0', transform: 'translateY(20px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
+      },
+      animation: {
+        fadeInUp: 'fadeInUp 0.6s ease-out forwards',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- implement About, Blog and Contact screens
- add routes for new pages
- enhance Navbar and Footer navigation
- provide simple fade-in animations in Tailwind config
- add API helper and backend route to send contact emails

## Testing
- `npm run lint` *(fails: missing eslint-plugin-react)*
- `python -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68645797407c832ab0b93b47ab36d35d