### PR TITLE
Add hover effect for feature cards

### DIFF
--- a/frontend/src/screens/HomePage.tsx
+++ b/frontend/src/screens/HomePage.tsx
@@ -50,7 +50,7 @@ const HomePage = () => {
         <h2 className="text-2xl font-bold text-center mb-12">Platform Features</h2>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
           {features.map((feature, index) => (
-            <div key={index} className="card flex flex-col items-center text-center">
+            <div key={index} className="feature-card flex flex-col items-center text-center">
               <div className="text-4xl mb-4">{feature.icon}</div>
               <h3 className="text-lg font-semibold mb-2">{feature.title}</h3>
               <p className="text-darkgray/70">{feature.description}</p>

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -45,6 +45,10 @@
     @apply bg-white rounded-lg shadow-md p-6;
   }
 
+  .feature-card {
+    @apply bg-white rounded-lg shadow-md p-6 transition-all duration-300 transform hover:-translate-y-1 hover:shadow-xl hover:bg-primary/5;
+  }
+
   .input {
     @apply border border-midgray rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent;
   }


### PR DESCRIPTION
## Summary
- add new `feature-card` style with subtle lift and highlight on hover
- use this style on the Platform Features cards

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6865014db140832a81b7dc44dcbbd75b