### PR TITLE
Add color invert hover effect to hero button

### DIFF
--- a/frontend/src/screens/HomePage.tsx
+++ b/frontend/src/screens/HomePage.tsx
@@ -39,7 +39,7 @@ const HomePage = () => {
         </p>
         <Link
           to={username ? '/model-builder' : '/signup'}
-          className="btn text-lg py-3 px-8 text-white bg-gradient-to-r from-primary to-secondary shadow-md hover:shadow-lg hover:-translate-y-1 transition-all duration-300"
+          className="btn text-lg py-3 px-8 text-white bg-gradient-to-r from-primary to-secondary shadow-md hover:shadow-lg hover:-translate-y-1 transition-all duration-300 hover-invert"
         >
           {username ? 'Build Your Model' : 'Get Started'}
         </Link>

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -49,6 +49,11 @@
     @apply bg-white rounded-lg shadow-md p-6 transition-all duration-300 transform hover:-translate-y-1 hover:shadow-xl hover:bg-primary/5;
   }
 
+  /* Utility to invert colors on hover */
+  .hover-invert:hover {
+    filter: invert(1);
+  }
+
   .input {
     @apply border border-midgray rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent;
   }


### PR DESCRIPTION
## Summary
- add a `hover-invert` utility class
- invert colors on the "Get Started" / "Build Your Model" button when hovered

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `npm run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react")*

------
https://chatgpt.com/codex/tasks/task_e_686506a7f904832ab67d20b665f11d23