### PR TITLE
Improve error surface during registration

### DIFF
--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -118,8 +118,15 @@ export const sendContactMessage = async (
 };
 
 export const registerUser = async (username: string, password: string) => {
-  const response = await api.post('/register', { username, password });
-  return response.data;
+  try {
+    const response = await api.post('/register', { username, password });
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      throw error.response.data;
+    }
+    throw error;
+  }
 };
 
 export const loginUser = async (username: string, password: string) => {


### PR DESCRIPTION
## Summary
- surface backend error message when signup fails

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*
- `pytest -q` *(fails: ModuleNotFoundError: requests)*

------
https://chatgpt.com/codex/tasks/task_e_686635bbc538832a8a881caa5c6d520c