### PR TITLE
Add avatar support for user accounts

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -38,10 +38,16 @@ def init_db():
             CREATE TABLE IF NOT EXISTS users (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 username TEXT UNIQUE NOT NULL,
-                password TEXT NOT NULL
+                password TEXT NOT NULL,
+                avatar TEXT
             )
             """
         )
+        # Ensure avatar column exists for older installations
+        try:
+            conn.execute("ALTER TABLE users ADD COLUMN avatar TEXT")
+        except sqlite3.OperationalError:
+            pass
         conn.commit()
 
 
@@ -240,13 +246,14 @@ def register():
     data = request.get_json()
     username = data.get('username')
     password = data.get('password')
+    avatar = data.get('avatar', 'avatar1.svg')
     if not username or not password:
         return jsonify({'error': 'Username and password required'}), 400
     try:
         with get_db_connection() as conn:
             conn.execute(
-                'INSERT INTO users (username, password) VALUES (?, ?)',
-                (username, generate_password_hash(password))
+                'INSERT INTO users (username, password, avatar) VALUES (?, ?, ?)',
+                (username, generate_password_hash(password), avatar)
             )
             conn.commit()
         return jsonify({'message': 'User registered successfully'})
@@ -267,10 +274,10 @@ def login():
         return jsonify({'error': 'Username and password required'}), 400
     try:
         with get_db_connection() as conn:
-            cur = conn.execute('SELECT password FROM users WHERE username=?', (username,))
+            cur = conn.execute('SELECT password, avatar FROM users WHERE username=?', (username,))
             row = cur.fetchone()
         if row and check_password_hash(row['password'], password):
-            return jsonify({'message': 'Login successful'})
+            return jsonify({'message': 'Login successful', 'username': username, 'avatar': row['avatar']})
         return jsonify({'error': 'Invalid credentials'}), 401
     except Exception as e:
         return jsonify({'error': str(e)}), 500

--- a/frontend/public/avatars/avatar1.svg
+++ b/frontend/public/avatars/avatar1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+  <circle cx="32" cy="32" r="32" fill="#3b82f6" />
+  <text x="32" y="38" font-size="32" text-anchor="middle" fill="white" font-family="Arial">A</text>
+</svg>

--- a/frontend/public/avatars/avatar2.svg
+++ b/frontend/public/avatars/avatar2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+  <circle cx="32" cy="32" r="32" fill="#10b981" />
+  <text x="32" y="38" font-size="32" text-anchor="middle" fill="white" font-family="Arial">B</text>
+</svg>

--- a/frontend/public/avatars/avatar3.svg
+++ b/frontend/public/avatars/avatar3.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+  <circle cx="32" cy="32" r="32" fill="#ef4444" />
+  <text x="32" y="38" font-size="32" text-anchor="middle" fill="white" font-family="Arial">C</text>
+</svg>

--- a/frontend/public/avatars/avatar4.svg
+++ b/frontend/public/avatars/avatar4.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+  <circle cx="32" cy="32" r="32" fill="#8b5cf6" />
+  <text x="32" y="38" font-size="32" text-anchor="middle" fill="white" font-family="Arial">D</text>
+</svg>

--- a/frontend/public/avatars/avatar5.svg
+++ b/frontend/public/avatars/avatar5.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+  <circle cx="32" cy="32" r="32" fill="#f97316" />
+  <text x="32" y="38" font-size="32" text-anchor="middle" fill="white" font-family="Arial">E</text>
+</svg>

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -5,7 +5,7 @@ import { AuthContext } from '../contexts/AuthContext';
 const Navbar = () => {
   const location = useLocation();
   const navigate = useNavigate();
-  const { username, logout } = useContext(AuthContext);
+  const { username, avatar, logout } = useContext(AuthContext);
   const [menuOpen, setMenuOpen] = useState(false);
 
   const handleLogout = () => {
@@ -86,6 +86,13 @@ const Navbar = () => {
                   onClick={() => setMenuOpen(!menuOpen)}
                   className="font-bold text-blue-800 flex items-center focus:outline-none"
                 >
+                  {avatar && (
+                    <img
+                      src={`/avatars/${avatar}`}
+                      alt="avatar"
+                      className="w-8 h-8 rounded-full mr-2"
+                    />
+                  )}
                   {username}
                   <svg
                     className={`w-4 h-4 ml-1 transition-transform transform ${menuOpen ? 'rotate-180' : ''}`}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -2,38 +2,49 @@ import { createContext, useEffect, useState, ReactNode } from 'react';
 
 interface AuthContextProps {
   username: string | null;
-  login: (name: string) => void;
+  avatar: string | null;
+  login: (name: string, avatar: string) => void;
   logout: () => void;
 }
 
 export const AuthContext = createContext<AuthContextProps>({
   username: null,
+  avatar: null,
   login: () => {},
   logout: () => {},
 });
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [username, setUsername] = useState<string | null>(null);
+  const [avatar, setAvatar] = useState<string | null>(null);
 
   useEffect(() => {
-    const stored = localStorage.getItem('username');
-    if (stored) {
-      setUsername(stored);
+    const storedName = localStorage.getItem('username');
+    const storedAvatar = localStorage.getItem('avatar');
+    if (storedName) {
+      setUsername(storedName);
+    }
+    if (storedAvatar) {
+      setAvatar(storedAvatar);
     }
   }, []);
 
-  const login = (name: string) => {
+  const login = (name: string, userAvatar: string) => {
     localStorage.setItem('username', name);
+    localStorage.setItem('avatar', userAvatar);
     setUsername(name);
+    setAvatar(userAvatar);
   };
 
   const logout = () => {
     localStorage.removeItem('username');
+    localStorage.removeItem('avatar');
     setUsername(null);
+    setAvatar(null);
   };
 
   return (
-    <AuthContext.Provider value={{ username, login, logout }}>
+    <AuthContext.Provider value={{ username, avatar, login, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/screens/LoginPage.tsx
+++ b/frontend/src/screens/LoginPage.tsx
@@ -14,8 +14,8 @@ const LoginPage = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await loginUser(username, password);
-      login(username);
+      const data = await loginUser(username, password);
+      login(data.username, data.avatar);
       navigate('/');
     } catch (err: any) {
       setError(err?.error || 'Incorrect username or password.');

--- a/frontend/src/screens/SignupPage.tsx
+++ b/frontend/src/screens/SignupPage.tsx
@@ -6,13 +6,14 @@ const SignupPage = () => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
+  const [selectedAvatar, setSelectedAvatar] = useState('avatar1.svg');
   const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await registerUser(username, password);
+      await registerUser(username, password, selectedAvatar);
       navigate('/login');
     } catch (err: any) {
       setError(err?.error || 'Signup failed');
@@ -24,6 +25,17 @@ const SignupPage = () => {
       <h2 className="text-2xl font-bold text-center mb-6">Sign Up</h2>
       {error && <p className="text-warning mb-4 text-center">{error}</p>}
       <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="flex justify-center space-x-2">
+          {['avatar1.svg','avatar2.svg','avatar3.svg','avatar4.svg','avatar5.svg'].map((av) => (
+            <img
+              key={av}
+              src={`/avatars/${av}`}
+              alt={av}
+              onClick={() => setSelectedAvatar(av)}
+              className={`w-12 h-12 rounded-full cursor-pointer border-2 ${selectedAvatar === av ? 'border-primary' : 'border-transparent'}`}
+            />
+          ))}
+        </div>
         <input
           type="text"
           className="input w-full"

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -117,9 +117,13 @@ export const sendContactMessage = async (
   return response.data;
 };
 
-export const registerUser = async (username: string, password: string) => {
+export const registerUser = async (
+  username: string,
+  password: string,
+  avatar: string
+) => {
   try {
-    const response = await api.post('/register', { username, password });
+    const response = await api.post('/register', { username, password, avatar });
     return response.data;
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
@@ -131,7 +135,7 @@ export const registerUser = async (username: string, password: string) => {
 
 export const loginUser = async (username: string, password: string) => {
   const response = await api.post('/login', { username, password });
-  return response.data;
+  return response.data as { message: string; username: string; avatar: string };
 };
 
 export default api;


### PR DESCRIPTION
## Summary
- update database schema to store user avatar
- send avatar with user registration and login
- allow avatar selection during sign up
- keep avatar info in auth context
- show avatar next to username in navbar
- provide 5 simple avatars as SVG files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `npm run lint` *(fails: ESLint couldn't find the plugin 'eslint-plugin-react')*
- `python -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_686636984d70832aa07c341d6aa33845