### PR TITLE
Enable custom SAM naming in uploads

### DIFF
--- a/frontend/src/components/FileUploader.tsx
+++ b/frontend/src/components/FileUploader.tsx
@@ -1,14 +1,18 @@
 import { useState, useRef } from 'react';
 import { SAM } from '../utils/types';
-import { parseSamFromCsv, parseSamFromExcel } from '../utils/samUtils';
+import { ParsedSam, parseSamFromCsv, parseSamFromExcel } from '../utils/samUtils';
 
 interface FileUploaderProps {
   onSamLoaded: (sam: SAM) => void;
+  goods: string[];
+  factors: string[];
+  households: string[];
 }
 
-const FileUploader = ({ onSamLoaded }: FileUploaderProps) => {
+const FileUploader = ({ onSamLoaded, goods, factors, households }: FileUploaderProps) => {
   const [isDragging, setIsDragging] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [warning, setWarning] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
@@ -42,19 +46,58 @@ const FileUploader = ({ onSamLoaded }: FileUploaderProps) => {
 
   const processFile = async (file: File) => {
     try {
-      let sam: SAM | null = null;
+      let parsed: ParsedSam | null = null;
       
       if (file.name.endsWith('.csv')) {
         const text = await file.text();
-        sam = parseSamFromCsv(text);
+        parsed = parseSamFromCsv(text);
       } else if (file.name.endsWith('.xlsx') || file.name.endsWith('.xls')) {
-        sam = await parseSamFromExcel(file);
+        parsed = await parseSamFromExcel(file);
       } else {
         setError('Unsupported file format. Please upload a CSV or Excel file.');
         return;
       }
-      
-      if (sam) {
+
+      if (parsed) {
+        const expectedEntries = [...goods, ...factors, ...households];
+        const headerSet = new Set(parsed.columnNames.map(n => n.trim()));
+        const rowSet = new Set(parsed.rowNames.map(n => n.trim()));
+        const expectedSet = new Set(expectedEntries.map(n => n.trim()));
+
+        let finalData = parsed.data;
+        let showWarning = false;
+
+        const namesMatch =
+          headerSet.size === expectedSet.size &&
+          rowSet.size === expectedSet.size &&
+          [...expectedSet].every(n => headerSet.has(n) && rowSet.has(n));
+
+        if (namesMatch) {
+          const rowIndex = new Map(parsed.rowNames.map((n, i) => [n.trim(), i]));
+          const colIndex = new Map(parsed.columnNames.map((n, i) => [n.trim(), i]));
+
+          finalData = expectedEntries.map(rowName => {
+            const r = parsed.data[rowIndex.get(rowName)!];
+            return expectedEntries.map(colName => r[colIndex.get(colName)!]);
+          });
+        } else {
+          showWarning = true;
+        }
+
+        const sam: SAM = {
+          entries: expectedEntries,
+          goods,
+          factors,
+          households,
+          data: finalData,
+        };
+
+        if (showWarning) {
+          setWarning('Uploaded names do not match the configured names. Using configured names instead.');
+        } else {
+          setWarning(null);
+        }
+
         onSamLoaded(sam);
       } else {
         setError('Failed to parse the SAM data. Please check the file format.');
@@ -118,6 +161,11 @@ const FileUploader = ({ onSamLoaded }: FileUploaderProps) => {
       {error && (
         <div className="mt-2 text-sm text-warning">
           {error}
+        </div>
+      )}
+      {warning && !error && (
+        <div className="mt-2 text-sm text-warning">
+          {warning}
         </div>
       )}
     </div>

--- a/frontend/src/screens/ModelBuilderPage.tsx
+++ b/frontend/src/screens/ModelBuilderPage.tsx
@@ -721,7 +721,12 @@ const ModelBuilderPage = () => {
 
                 <div className="mb-6">
                   <h4 className="text-lg font-medium mb-2">Upload SAM</h4>
-                  <FileUploader onSamLoaded={handleSamUpload} />
+                  <FileUploader
+                    onSamLoaded={handleSamUpload}
+                    goods={sectorNames}
+                    factors={factorNames}
+                    households={householdNames}
+                  />
                 </div>
 
                 <div className="relative flex items-center mb-6">

--- a/frontend/src/utils/samUtils.ts
+++ b/frontend/src/utils/samUtils.ts
@@ -2,44 +2,51 @@ import { SAM } from './types';
 import * as ExcelJS from 'exceljs';
 import Papa from 'papaparse';
 
-export const parseSamFromCsv = (csvContent: string): SAM | null => {
+export interface ParsedSam {
+  columnNames: string[];
+  rowNames: string[];
+  data: number[][];
+}
+
+export const parseSamFromCsv = (csvContent: string): ParsedSam | null => {
   try {
-    const result = Papa.parse(csvContent, { header: true });
+    const result = Papa.parse<string[]>(csvContent.trim());
     if (result.errors.length > 0) {
       console.error('CSV parsing errors:', result.errors);
       return null;
     }
 
-    const data = result.data as Record<string, string>[];
-    const headers = Object.keys(data[0]).filter(h => h !== '');
-    
-    // Extract SAM entries, goods, factors, households
-    const entries = [...headers];
-    
-    // Simplified for MVP - we'll refine this with backend coordination
-    const goods = entries.filter(e => e.startsWith('SECTOR') || ['BRD', 'MLK'].includes(e));
-    const factors = entries.filter(e => e.startsWith('FACTOR') || ['CAP', 'LAB'].includes(e));
-    const households = entries.filter(e => e.startsWith('HH') || ['HOH'].includes(e));
-    
-    // Convert data to numeric matrix
-    const numericData = data.map(row => {
-      return headers.map(header => parseFloat(row[header] || '0'));
-    });
-    
-    return {
-      entries,
-      goods,
-      factors,
-      households,
-      data: numericData
-    };
+    const rows = result.data as string[][];
+    if (!rows || rows.length === 0) return null;
+
+    const header = rows[0];
+    const columnNames = header.slice(1).map(h => String(h).trim());
+
+    const rowNames: string[] = [];
+    const numericData: number[][] = [];
+
+    for (let i = 1; i < rows.length; i++) {
+      const row = rows[i];
+      if (!row || row.length === 0) continue;
+
+      rowNames.push(String(row[0]).trim());
+      const values: number[] = [];
+      for (let j = 1; j <= columnNames.length; j++) {
+        const val = row[j];
+        const num = parseFloat(val ?? '0');
+        values.push(isNaN(num) ? 0 : num);
+      }
+      numericData.push(values);
+    }
+
+    return { columnNames, rowNames, data: numericData };
   } catch (error) {
     console.error('Error parsing CSV:', error);
     return null;
   }
 };
 
-export const parseSamFromExcel = async (file: File): Promise<SAM | null> => {
+export const parseSamFromExcel = async (file: File): Promise<ParsedSam | null> => {
   try {
     const workbook = new ExcelJS.Workbook();
     const arrayBuffer = await file.arrayBuffer();


### PR DESCRIPTION
## Summary
- parse SAM files generically to read custom row/column names
- expose parsed SAM structure to uploader
- warn when uploaded names differ from configured names
- reorder uploaded data to match configured order
- pass configured names to the uploader

## Testing
- `npm run lint` *(fails: ESLint couldn't find eslint-plugin-react)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6866377b602c832a8924622fc8edc7aa