### PR TITLE
Enhance SAM tools

### DIFF
--- a/frontend/src/components/SAMTable.tsx
+++ b/frontend/src/components/SAMTable.tsx
@@ -192,7 +192,7 @@ const SAMTable = ({ sam, onChange, readOnly = false }: SAMTableProps) => {
   return (
     <div className="w-full">
       <div
-        className="ag-theme-alpine w-full h-[60vh] border border-midgray"
+        className="ag-theme-alpine w-full max-h-[60vh] border border-midgray overflow-auto"
       >
         {!sam || !sam.entries || sam.entries.length === 0 ? (
           <div className="flex flex-col h-full">
@@ -204,10 +204,9 @@ const SAMTable = ({ sam, onChange, readOnly = false }: SAMTableProps) => {
           </div>
         ) : (
           /* Key AG-Grid fixes:
-             1. Added style with proper height
-             2. Added domLayout="normal"
-             3. Added immutableData={false}
-             4. Added key based on entries length to force re-render
+             1. Auto height layout to fit content
+             2. Added immutableData={false}
+             3. Added key based on entries length to force re-render
           */
           <AgGridReact
             className="w-full h-full"
@@ -223,7 +222,7 @@ const SAMTable = ({ sam, onChange, readOnly = false }: SAMTableProps) => {
               editable: !readOnly,
               minWidth: 100
             }}
-            domLayout="normal"
+            domLayout="autoHeight"
             immutableData={false}
             rowHeight={40}
           />

--- a/frontend/src/screens/ModelBuilderPage.tsx
+++ b/frontend/src/screens/ModelBuilderPage.tsx
@@ -7,7 +7,13 @@ import ResultsDisplay from '../components/ResultsDisplay';
 import ComparisonDisplay from '../components/ComparisonDisplay';
 import { ModelTemplate, SAM, ModelParameters, ModelResults, ScenarioComparison } from '../utils/types';
 import templates from '../utils/templateData';
-import { generateDefaultSam, generateEmptySam, validateSam, exportSamToCsv } from '../utils/samUtils';
+import {
+  generateDefaultSam,
+  generateEmptySam,
+  validateSam,
+  exportSamToCsv,
+  exportSamToExcel,
+} from '../utils/samUtils';
 import { solveModel, compareScenarios } from '../utils/api';
 
 const ModelBuilderPage = () => {
@@ -33,6 +39,8 @@ const ModelBuilderPage = () => {
   const [samData, setSamData] = useState<SAM>(generateDefaultSam());
   const [isCustomSam, setIsCustomSam] = useState<boolean>(false);
   const [samConfigured, setSamConfigured] = useState<boolean>(false);
+  const [samValid, setSamValid] = useState<boolean>(true);
+  const [samValidationMessage, setSamValidationMessage] = useState<string | null>(null);
   
   // Parameters
   const [modelParameters, setModelParameters] = useState<ModelParameters>({
@@ -178,6 +186,13 @@ const ModelBuilderPage = () => {
       });
     }
   }, [currentStep, useCustomModel, sectorCount, factorCount, householdCount, sectorNames, factorNames, householdNames, useCustomNames]);
+
+  // Validate SAM whenever it changes
+  useEffect(() => {
+    const validation = validateSam(samData);
+    setSamValid(validation.valid);
+    setSamValidationMessage(validation.valid ? null : validation.message || 'Invalid SAM');
+  }, [samData]);
   
   // Handle template selection
   const handleSelectTemplate = (template: ModelTemplate) => {
@@ -278,6 +293,20 @@ const ModelBuilderPage = () => {
     const link = document.createElement('a');
     link.href = url;
     link.setAttribute('download', 'sam.csv');
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  // Download the current SAM as an Excel file
+  const handleDownloadExcel = async () => {
+    const blob = await exportSamToExcel(samData);
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', 'sam.xlsx');
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
@@ -738,7 +767,23 @@ const ModelBuilderPage = () => {
                 </div>
 
                 <div className="mb-6">
-                  <h4 className="text-lg font-medium mb-2">SAM Editor</h4>
+                  <div className="flex items-center justify-between mb-2">
+                    <h4 className="text-lg font-medium">SAM Editor</h4>
+                    <div className="flex gap-2">
+                      <button
+                        onClick={handleDownloadCsv}
+                        className="btn bg-white border border-midgray text-darkgray hover:bg-neutral text-sm"
+                      >
+                        Download CSV
+                      </button>
+                      <button
+                        onClick={handleDownloadExcel}
+                        className="btn bg-white border border-midgray text-darkgray hover:bg-neutral text-sm"
+                      >
+                        Download Excel
+                      </button>
+                    </div>
+                  </div>
                   <SAMTable sam={samData} onChange={setSamData} />
                 </div>
               </div>
@@ -764,7 +809,8 @@ const ModelBuilderPage = () => {
             <button
               onClick={handleSolveModel}
               className="btn btn-primary"
-              disabled={isLoading || !samConfigured}
+              disabled={isLoading || !samConfigured || !samValid}
+              title={!samValid ? samValidationMessage || 'The SAM matrix is not balanced' : undefined}
             >
               {isLoading ? 'Solving...' : 'Solve Model'}
             </button>

--- a/frontend/src/utils/samUtils.ts
+++ b/frontend/src/utils/samUtils.ts
@@ -162,8 +162,24 @@ export const exportSamToCsv = (sam: SAM): string => {
     });
     return rowData;
   });
-  
+
   return Papa.unparse(rows);
+};
+
+export const exportSamToExcel = async (sam: SAM): Promise<Blob> => {
+  const workbook = new ExcelJS.Workbook();
+  const worksheet = workbook.addWorksheet('SAM');
+
+  worksheet.addRow(['', ...sam.entries]);
+  sam.data.forEach((row, idx) => {
+    worksheet.addRow([sam.entries[idx], ...row]);
+  });
+
+  const buffer = await workbook.xlsx.writeBuffer();
+  return new Blob([buffer], {
+    type:
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  });
 };
 
 export const validateSam = (sam: SAM): { valid: boolean; message?: string } => {
@@ -185,15 +201,25 @@ export const validateSam = (sam: SAM): { valid: boolean; message?: string } => {
   
   for (const row of sam.data) {
     if (row.length !== sam.entries.length) {
-      return { 
-        valid: false, 
-        message: `SAM matrix columns (${row.length}) do not match entries count (${sam.entries.length})` 
+      return {
+        valid: false,
+        message: `SAM matrix columns (${row.length}) do not match entries count (${sam.entries.length})`
       };
     }
   }
-  
-  // In a full implementation, we would check row/column sums
-  // For MVP, we'll do a simplified check
-  
+
+  // Check that row sums equal column sums (balanced SAM)
+  const rowSums = sam.data.map(row => row.reduce((sum, val) => sum + Number(val || 0), 0));
+  const colSums = sam.entries.map((_, colIndex) => sam.data.reduce((sum, row) => sum + Number(row[colIndex] || 0), 0));
+
+  for (let i = 0; i < sam.entries.length; i++) {
+    if (Math.abs(rowSums[i] - colSums[i]) > 1e-6) {
+      return {
+        valid: false,
+        message: `Row and column totals differ for ${sam.entries[i]}`,
+      };
+    }
+  }
+
   return { valid: true };
 };


### PR DESCRIPTION
## Summary
- add ability to export SAM matrix to CSV or Excel
- validate SAM matrix balance (row sums must equal column sums)
- show error tooltip and disable Solve button when SAM is not balanced
- tweak SAM editor grid layout and add download buttons

## Testing
- `npm run lint` *(fails: ESLint plugin missing)*
- `pytest` *(fails: ModuleNotFoundError: requests)*

------
https://chatgpt.com/codex/tasks/task_e_686658ebcf68832ab8f6ad83623c9aed