### PR TITLE
Add automatic avatars

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -246,7 +246,11 @@ def register():
     data = request.get_json()
     username = data.get('username')
     password = data.get('password')
-    avatar = data.get('avatar', 'avatar1.svg')
+    avatar = data.get('avatar')
+    if not avatar:
+        # Generate default avatar as "<LETTER>|<COLOR>"
+        color = '#%06x' % random.randint(0, 0xFFFFFF)
+        avatar = f"{username[0].upper()}|{color}"
     if not username or not password:
         return jsonify({'error': 'Username and password required'}), 400
     try:

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -87,11 +87,17 @@ const Navbar = () => {
                   className="font-bold text-blue-800 flex items-center focus:outline-none"
                 >
                   {avatar && (
-                    <img
-                      src={`/avatars/${avatar}`}
-                      alt="avatar"
-                      className="w-8 h-8 rounded-full mr-2"
-                    />
+                    (() => {
+                      const [letter, color] = avatar.split('|');
+                      return (
+                        <div
+                          className="w-8 h-8 rounded-full flex items-center justify-center text-white font-bold mr-2"
+                          style={{ backgroundColor: color }}
+                        >
+                          {letter}
+                        </div>
+                      );
+                    })()
                   )}
                   {username}
                   <svg

--- a/frontend/src/screens/SignupPage.tsx
+++ b/frontend/src/screens/SignupPage.tsx
@@ -6,14 +6,17 @@ const SignupPage = () => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
-  const [selectedAvatar, setSelectedAvatar] = useState('avatar1.svg');
   const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await registerUser(username, password, selectedAvatar);
+      const color = `#${Math.floor(Math.random() * 0xffffff)
+        .toString(16)
+        .padStart(6, '0')}`;
+      const avatar = `${username.charAt(0).toUpperCase()}|${color}`;
+      await registerUser(username, password, avatar);
       navigate('/login');
     } catch (err: any) {
       setError(err?.error || 'Signup failed');
@@ -25,17 +28,6 @@ const SignupPage = () => {
       <h2 className="text-2xl font-bold text-center mb-6">Sign Up</h2>
       {error && <p className="text-warning mb-4 text-center">{error}</p>}
       <form onSubmit={handleSubmit} className="space-y-4">
-        <div className="flex justify-center space-x-2">
-          {['avatar1.svg','avatar2.svg','avatar3.svg','avatar4.svg','avatar5.svg'].map((av) => (
-            <img
-              key={av}
-              src={`/avatars/${av}`}
-              alt={av}
-              onClick={() => setSelectedAvatar(av)}
-              className={`w-12 h-12 rounded-full cursor-pointer border-2 ${selectedAvatar === av ? 'border-primary' : 'border-transparent'}`}
-            />
-          ))}
-        </div>
         <input
           type="text"
           className="input w-full"

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -117,6 +117,7 @@ export const sendContactMessage = async (
   return response.data;
 };
 
+// avatar format "<LETTER>|<COLOR>"
 export const registerUser = async (
   username: string,
   password: string,


### PR DESCRIPTION
## Summary
- generate a random color avatar based on the first letter of the username
- remove avatar selection in the signup page
- display the generated avatar in the navbar
- fallback avatar generation in backend

## Testing
- `npm run lint` *(fails: eslint-plugin-react not found)*
- `pytest -q` *(fails: ModuleNotFoundError: requests)*

------
https://chatgpt.com/codex/tasks/task_e_6866833460a4832a83b3aa0619d57229