### PR TITLE
Fix SAM shape check order in FileUploader

### DIFF
--- a/frontend/src/components/FileUploader.tsx
+++ b/frontend/src/components/FileUploader.tsx
@@ -60,13 +60,23 @@ const FileUploader = ({ onSamLoaded, goods, factors, households }: FileUploaderP
 
       if (parsed) {
         const expectedEntries = [...goods, ...factors, ...households];
-        const trimmedExpected = expectedEntries.map(n => n.trim());
+        const expectedSize = expectedEntries.length;
+
         const trimmedHeader = parsed.columnNames.map(n => n.trim());
         const trimmedRows = parsed.rowNames.map(n => n.trim());
 
+        if (
+          trimmedHeader.length !== expectedSize ||
+          trimmedRows.length !== expectedSize ||
+          parsed.data.length !== expectedSize ||
+          parsed.data.some(row => row.length !== expectedSize)
+        ) {
+          setError(`SAM matrix must be ${expectedSize}x${expectedSize}`);
+          return;
+        }
+
+        const trimmedExpected = expectedEntries.map(n => n.trim());
         const namesMatch =
-          trimmedHeader.length === trimmedExpected.length &&
-          trimmedRows.length === trimmedExpected.length &&
           trimmedHeader.every((n, idx) => n === trimmedExpected[idx]) &&
           trimmedRows.every((n, idx) => n === trimmedExpected[idx]);
 
@@ -74,15 +84,6 @@ const FileUploader = ({ onSamLoaded, goods, factors, households }: FileUploaderP
           setError(
             `Names must match configured entries: ${trimmedExpected.join(', ')}`
           );
-          return;
-        }
-
-        const expectedSize = trimmedExpected.length;
-        if (
-          parsed.data.length !== expectedSize ||
-          parsed.data.some(row => row.length !== expectedSize)
-        ) {
-          setError(`SAM matrix must be ${expectedSize}x${expectedSize}`);
           return;
         }
 


### PR DESCRIPTION
## Summary
- check the uploaded SAM matrix shape before validating names

## Testing
- `npm --prefix frontend run lint` *(fails: plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669f699310832a8d718f01a7f25870