### PR TITLE
Add customization availability check

### DIFF
--- a/frontend/src/screens/ModelBuilderPage.tsx
+++ b/frontend/src/screens/ModelBuilderPage.tsx
@@ -212,6 +212,12 @@ const ModelBuilderPage = () => {
   // Handle customization choice
   const handleCustomizationChoice = (isCustom: boolean) => {
     console.log('Customization choice made:', isCustom);
+    if (isCustom && selectedTemplate?.id !== 'simple-cge') {
+      setError(
+        'Customization for this model is currently unavailable. This feature will be added soon.'
+      );
+      return;
+    }
     setUseCustomModel(isCustom);
     setSamConfigured(false);
 


### PR DESCRIPTION
## Summary
- prevent customizing models other than Simple CGE
- show a helpful error message when user tries

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6868c28c6b9c832aa9f0f18689e31e5f