### PR TITLE
Fix repeated SAM console logs

### DIFF
--- a/frontend/src/components/ParameterInputs.tsx
+++ b/frontend/src/components/ParameterInputs.tsx
@@ -57,7 +57,9 @@ const ParameterInputs = ({ initialParams, sam, templateId, onChange }: Parameter
         b: defaultB
       });
     }
-  }, [sam.goods.length, sam.households.length, initialParams, templateId]);
+  // Note: removing `initialParams` from dependencies prevents a reinitialization
+  // loop when parent components update the parameters state.
+  }, [sam.goods.length, sam.households.length, templateId]);
 
   // When values change, call the onChange handler
   useEffect(() => {

--- a/frontend/src/screens/ModelBuilderPage.tsx
+++ b/frontend/src/screens/ModelBuilderPage.tsx
@@ -37,7 +37,8 @@ const ModelBuilderPage = () => {
   const [useCustomNames, setUseCustomNames] = useState<boolean>(false);
   
   // SAM data
-  const [samData, setSamData] = useState<SAM>(generateDefaultSam());
+  // Use functional initializer so the default SAM is generated only once
+  const [samData, setSamData] = useState<SAM>(() => generateDefaultSam());
   const [isCustomSam, setIsCustomSam] = useState<boolean>(false);
   const [samConfigured, setSamConfigured] = useState<boolean>(false);
   const [samValid, setSamValid] = useState<boolean>(true);


### PR DESCRIPTION
## Summary
- avoid regenerating the default SAM on each render
- prevent ParameterInputs from reinitializing values after every parent update

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_6868d0c97f5c832aaa19c13780f9c258