### PR TITLE
Add template fade-in animation

### DIFF
--- a/frontend/src/components/TemplateCard.tsx
+++ b/frontend/src/components/TemplateCard.tsx
@@ -5,9 +5,10 @@ interface TemplateCardProps {
   template: ModelTemplate;
   onSelect: (template: ModelTemplate) => void;
   isSelected: boolean;
+  delay?: number;
 }
 
-const TemplateCard = ({ template, onSelect, isSelected }: TemplateCardProps) => {
+const TemplateCard = ({ template, onSelect, isSelected, delay = 0 }: TemplateCardProps) => {
   // Get the correct icon based on template type
   const getTemplateIcon = () => {
     switch (template.type) {
@@ -25,12 +26,13 @@ const TemplateCard = ({ template, onSelect, isSelected }: TemplateCardProps) => 
   };
 
   return (
-    <div 
+    <div
       className={`card transition-all duration-300 h-full flex flex-col ${
-        isSelected 
-          ? 'border-2 border-primary ring-2 ring-primary/30 transform scale-[1.02]' 
+        isSelected
+          ? 'border-2 border-primary ring-2 ring-primary/30 transform scale-[1.02]'
           : 'hover:shadow-lg border border-midgray/20'
-      }`}
+      } animate-fadeInUp`}
+      style={{ animationDelay: `${delay}s` }}
     >
       <div className="flex items-center mb-3">
         <span className="text-2xl mr-2">{getTemplateIcon()}</span>

--- a/frontend/src/screens/ModelBuilderPage.tsx
+++ b/frontend/src/screens/ModelBuilderPage.tsx
@@ -566,12 +566,13 @@ const ModelBuilderPage = () => {
           </p>
           
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {templates.map((template) => (
+            {templates.map((template, index) => (
               <TemplateCard
                 key={template.id}
                 template={template}
                 onSelect={handleSelectTemplate}
                 isSelected={selectedTemplate?.id === template.id}
+                delay={index * 0.2}
               />
             ))}
           </div>


### PR DESCRIPTION
## Summary
- add optional animation delay to `TemplateCard`
- show template cards with sequential `fadeInUp` animation

## Testing
- `npm run lint` *(fails: ESLint couldn't find the plugin due to missing modules)*
- `npm run build` *(fails: TypeScript compilation failed due to missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68693700ba04832a8c844773538a7639