### PR TITLE
Display team photos and logo

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/png" href="/static/logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CGE Model Builder Platform</title>
     <meta name="description" content="Build and analyze Computational General Equilibrium models without coding" />

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,11 +1,14 @@
+import logo from '../../static/logo.png';
+
 const Footer = () => {
   return (
     <footer className="bg-white py-6 mt-12">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="border-t border-midgray/30 pt-6">
           <div className="flex flex-col md:flex-row md:justify-between items-center">
-            <p className="text-sm text-darkgray/70">
-              &copy; {new Date().getFullYear()} CGE Model Builder Platform
+            <p className="text-sm text-darkgray/70 flex items-center space-x-2">
+              <img src={logo} alt="Kaizen logo" className="w-6 h-6" />
+              <span>&copy; {new Date().getFullYear()} CGE Model Builder Platform</span>
             </p>
             <div className="mt-4 md:mt-0">
               <ul className="flex space-x-6">

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,5 +1,6 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useContext, useState } from 'react';
+import logo from '../../static/logo.png';
 import { AuthContext } from '../contexts/AuthContext';
 
 const Navbar = () => {
@@ -20,8 +21,9 @@ const Navbar = () => {
         <div className="flex justify-between h-16">
           <div className="flex">
             <div className="flex-shrink-0 flex items-center">
-              <Link to="/" className="text-xl font-bold text-primary">
-                CGE Model Builder
+              <Link to="/" className="flex items-center space-x-2 text-xl font-bold text-primary">
+                <img src={logo} alt="Kaizen logo" className="w-8 h-8" />
+                <span>CGE Model Builder</span>
               </Link>
             </div>
             <div className="hidden sm:ml-6 sm:flex sm:space-x-8">

--- a/frontend/src/screens/AboutPage.tsx
+++ b/frontend/src/screens/AboutPage.tsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import ibrahimImg from '../../static/ibrahim.jpg';
+import almaenImg from '../../static/almaen.jpg';
+import ahmedImg from '../../static/ahmed.jpg';
 
 const AboutPage = () => {
   return (
@@ -22,20 +25,20 @@ const AboutPage = () => {
       <section className="space-y-6 animate-fadeInUp">
         <h2 className="text-2xl font-bold">Our Team</h2>
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
-          <div className="card text-center space-y-2">
-            <img src="https://via.placeholder.com/150" alt="Dr. Ibrahim Aljarrah" className="w-full" />
+          <div className="card text-center space-y-2 transition-all duration-300 transform hover:-translate-y-1 hover:shadow-lg">
+            <img src={ibrahimImg} alt="Dr. Ibrahim Aljarrah" className="w-full rounded-md" />
             <h3>Dr. Ibrahim Aljarrah</h3>
             <p className="text-sm">Founder &amp; Lead Economist</p>
             <p className="text-sm">PhD in Economic Modeling with 15+ years of experience in CGE model development.</p>
           </div>
-          <div className="card text-center space-y-2">
-            <img src="https://via.placeholder.com/150" alt="Almaen Salah" className="w-full" />
+          <div className="card text-center space-y-2 transition-all duration-300 transform hover:-translate-y-1 hover:shadow-lg">
+            <img src={almaenImg} alt="Almaen Salah" className="w-full rounded-md" />
             <h3>Almaen Salah</h3>
             <p className="text-sm">Chief Technology Officer</p>
             <p className="text-sm">Expert in computational methods and visualization of economic data.</p>
           </div>
-          <div className="card text-center space-y-2">
-            <img src="https://via.placeholder.com/150" alt="Ahmed Alqershi" className="w-full" />
+          <div className="card text-center space-y-2 transition-all duration-300 transform hover:-translate-y-1 hover:shadow-lg">
+            <img src={ahmedImg} alt="Ahmed Alqershi" className="w-full rounded-md" />
             <h3>Ahmed Alqershi</h3>
             <p className="text-sm">Lead Developer</p>
             <p className="text-sm">Specializes in creating interactive web applications for complex data.</p>


### PR DESCRIPTION
## Summary
- integrate team member photos in About page
- show company logo in Navbar and Footer
- use logo as favicon

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68693c13b544832a901e6b2448e1224d