### PR TITLE
Adjust template animations

### DIFF
--- a/frontend/src/components/TemplateCard.tsx
+++ b/frontend/src/components/TemplateCard.tsx
@@ -27,7 +27,7 @@ const TemplateCard = ({ template, onSelect, isSelected, delay = 0 }: TemplateCar
 
   return (
     <div
-      className={`card transition-all duration-300 h-full flex flex-col ${
+      className={`card transition-all duration-300 h-full flex flex-col opacity-0 ${
         isSelected
           ? 'border-2 border-primary ring-2 ring-primary/30 transform scale-[1.02]'
           : 'hover:shadow-lg border border-midgray/20'

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -22,7 +22,7 @@ export default {
         },
       },
       animation: {
-        fadeInUp: 'fadeInUp 0.6s ease-out forwards',
+        fadeInUp: 'fadeInUp 1.2s ease-out forwards',
       },
     },
   },


### PR DESCRIPTION
## Summary
- hide TemplateCard before fade-in animation starts
- slow down fadeInUp animation to 1.2s

## Testing
- `npm run lint` *(fails: ESLint couldn't find eslint-plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68693d52c1c4832a9e1f8fb23bb208ef