### PR TITLE
Refine username hover effect

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -86,7 +86,7 @@ const Navbar = () => {
               <div className="relative">
                 <button
                   onClick={() => setMenuOpen(!menuOpen)}
-                  className="group font-bold text-blue-800 flex items-center focus:outline-none transition-all duration-300 transform hover:-translate-y-1 hover:shadow-lg rounded-md px-2"
+                  className="group font-bold text-blue-800 flex items-center focus:outline-none rounded-md px-2 transition-colors duration-200 hover:text-primary"
                 >
                   {avatar && (
                     (() => {


### PR DESCRIPTION
## Summary
- remove upward translation on username button hover
- add subtle color change instead

## Testing
- `npm run lint` *(fails: eslint-plugin-react not installed)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686942a76b5c832a9d6d3f6b364c07bc