### PR TITLE
Fix scenario compare for Korea model

### DIFF
--- a/frontend/src/screens/ModelBuilderPage.tsx
+++ b/frontend/src/screens/ModelBuilderPage.tsx
@@ -411,6 +411,7 @@ const ModelBuilderPage = () => {
       // Call the API to compare scenarios
       const templateId = selectedTemplate?.id || 'simple-cge';
       const results = await compareScenarios(
+        templateId,
         modelParameters,
         scenarioParameters,
         isCustomSam ? samData : undefined

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -52,12 +52,14 @@ export const solveModel = async (
 };
 
 export const compareScenarios = async (
+  templateId: string,
   baselineParams: ModelParameters,
   scenarioParams: ModelParameters,
   sam?: SAM
 ): Promise<ScenarioComparison> => {
   try {
     const response = await api.post('/compare-scenarios', {
+      templateId,
       baselineParams,
       scenarioParams,
       sam,


### PR DESCRIPTION
## Summary
- include the selected template when comparing scenarios
- pass template id through the frontend when requesting a comparison

## Testing
- `npm run lint` *(fails: ESLint couldn't find the plugin 'eslint-plugin-react')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6869951f7ae8832aad6742cfbeb52895