### PR TITLE
Add country flag icons with react-country-flag

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "react-dom": "^18.2.0",
     "react-markdown": "^9.0.1",
     "react-router-dom": "^6.22.1",
+    "react-country-flag": "^3.0.5",
     "recharts": "^2.12.1"
   },
   "devDependencies": {

--- a/frontend/src/components/TemplateCard.tsx
+++ b/frontend/src/components/TemplateCard.tsx
@@ -1,5 +1,6 @@
 import { ModelTemplate } from '../utils/types';
 import ReactMarkdown from 'react-markdown';
+import ReactCountryFlag from 'react-country-flag';
 
 interface TemplateCardProps {
   template: ModelTemplate;
@@ -17,9 +18,23 @@ const TemplateCard = ({ template, onSelect, isSelected, delay = 0 }: TemplateCar
       case 'standard':
         return '📊';
       case 'cameroon':
-        return '🇨🇲';
+        return (
+          <ReactCountryFlag
+            countryCode="CM"
+            svg
+            style={{ width: '1.2em', height: '1.2em' }}
+            title="Cameroon"
+          />
+        );
       case 'korea':
-        return '🇰🇷';
+        return (
+          <ReactCountryFlag
+            countryCode="KR"
+            svg
+            style={{ width: '1.2em', height: '1.2em' }}
+            title="South Korea"
+          />
+        );
       default:
         return '📄';
     }


### PR DESCRIPTION
## Summary
- add `react-country-flag` dependency
- display Cameroon and South Korea flags using ReactCountryFlag in `TemplateCard`

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_686997e92df8832a8e98dc8f708fc786