### PR TITLE
Add Saudi CGE model template

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Future versions will add:
 - Standard CGE Model (with government, trade, and investment)
 - Cameroon CGE Model (11 sectors)
 - Korea CGE Model (3 sectors with multiple household types)
+- Saudi Arabia CGE Model (oil-driven economy with expat labor)
 
 ## Features
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -257,6 +257,18 @@ def solve_model():
                 print(stack_trace)
                 return jsonify({'error': error_message, 'trace': stack_trace}), 500
 
+        elif template_id == 'saudi-cge':
+            try:
+                from models.model_wrappers import solve_saudi
+                results = solve_saudi()
+                return jsonify(results)
+            except Exception as sa_error:
+                error_message = f"Error solving Saudi model: {sa_error}"
+                stack_trace = traceback.format_exc()
+                print(error_message)
+                print(stack_trace)
+                return jsonify({'error': error_message, 'trace': stack_trace}), 500
+
         else:
             # For other templates (not implemented in MVP)
             return jsonify({
@@ -391,6 +403,56 @@ def compare_scenarios():
                 })
             except Exception as kor_err:
                 error_message = f"Error comparing Korea scenarios: {kor_err}"
+                stack_trace = traceback.format_exc()
+                print(error_message)
+                print(stack_trace)
+                return jsonify({'error': error_message, 'trace': stack_trace}), 500
+
+        elif template_id == 'saudi-cge':
+            try:
+                from models.model_wrappers import solve_saudi
+                baseline_tariff = baseline_params.get('tariff')
+                baseline_itax = baseline_params.get('indirectTax')
+                baseline_htax = baseline_params.get('incomeTax')
+
+                scenario_tariff = scenario_params.get('tariff')
+                scenario_itax = scenario_params.get('indirectTax')
+                scenario_htax = scenario_params.get('incomeTax')
+
+                baseline_results = solve_saudi(baseline_tariff, baseline_itax, baseline_htax)
+                scenario_results = solve_saudi(scenario_tariff, scenario_itax, scenario_htax)
+
+                def diff_dict(base: Dict[str, float], other: Dict[str, float]):
+                    d = {}
+                    for k in base:
+                        b = float(base[k])
+                        o = float(other.get(k, 0))
+                        val = o - b
+                        pct = (val / b * 100) if b != 0 else 0
+                        d[k] = {'value': val, 'percentChange': pct}
+                    return d
+
+                price_diffs = diff_dict(baseline_results['prices'], scenario_results['prices'])
+                prod_diffs = diff_dict(baseline_results['production'], scenario_results['production'])
+
+                util_diff = scenario_results['utility'] - baseline_results['utility']
+                util_pct = (util_diff / baseline_results['utility'] * 100) if baseline_results['utility'] else 0
+
+                gdp_diff = scenario_results['gdp'] - baseline_results['gdp']
+                gdp_pct = (gdp_diff / baseline_results['gdp'] * 100) if baseline_results['gdp'] else 0
+
+                return jsonify({
+                    'baseline': baseline_results,
+                    'scenario': scenario_results,
+                    'differences': {
+                        'prices': price_diffs,
+                        'production': prod_diffs,
+                        'utility': {'value': util_diff, 'percentChange': util_pct},
+                        'gdp': {'value': gdp_diff, 'percentChange': gdp_pct},
+                    }
+                })
+            except Exception as sa_err:
+                error_message = f"Error comparing Saudi scenarios: {sa_err}"
                 stack_trace = traceback.format_exc()
                 print(error_message)
                 print(stack_trace)

--- a/backend/models/model_wrappers.py
+++ b/backend/models/model_wrappers.py
@@ -1,7 +1,7 @@
 import importlib
 from typing import List, Optional, Dict
 
-from . import camcge, korcge
+from . import camcge, korcge, saudicge
 
 
 def _extract_results(container) -> Dict[str, float]:
@@ -40,6 +40,28 @@ def solve_korea(
 ) -> Dict[str, float]:
     """Run the Korea CGE model with optional policy parameters."""
     mod = importlib.reload(korcge)
+
+    if tariff is not None:
+        for sec, val in zip(mod.data.sectors, tariff):
+            mod.tm[sec] = float(val)
+    if indirect_tax is not None:
+        for sec, val in zip(mod.data.sectors, indirect_tax):
+            mod.itax[sec] = float(val)
+    if income_tax is not None:
+        for hh, val in zip(mod.data.households, income_tax):
+            mod.htax[hh] = float(val)
+
+    mod.model1.solve(solver="CONOPT")
+    return _extract_results(mod.m)
+
+
+def solve_saudi(
+    tariff: Optional[List[float]] = None,
+    indirect_tax: Optional[List[float]] = None,
+    income_tax: Optional[List[float]] = None,
+) -> Dict[str, float]:
+    """Run the Saudi CGE model with optional policy parameters."""
+    mod = importlib.reload(saudicge)
 
     if tariff is not None:
         for sec, val in zip(mod.data.sectors, tariff):

--- a/frontend/src/components/ParameterInputs.tsx
+++ b/frontend/src/components/ParameterInputs.tsx
@@ -43,7 +43,7 @@ const ParameterInputs = ({ initialParams, sam, templateId, onChange }: Parameter
       );
       setBValues(defaultB);
 
-      if (templateId === 'korea-cge') {
+      if (templateId === 'korea-cge' || templateId === 'saudi-cge') {
         const defTariff = sam.goods.map((_, i) => initialParams?.tariff?.[i] ?? 0);
         const defIndirect = sam.goods.map((_, i) => initialParams?.indirectTax?.[i] ?? 0);
         setTariffValues(defTariff);
@@ -68,7 +68,7 @@ const ParameterInputs = ({ initialParams, sam, templateId, onChange }: Parameter
         alpha: alphaValues,
         b: bValues
       };
-      if (templateId === 'korea-cge') {
+      if (templateId === 'korea-cge' || templateId === 'saudi-cge') {
         params.tariff = tariffValues;
         params.indirectTax = indirectValues;
         params.incomeTax = incomeValues;
@@ -154,7 +154,7 @@ const ParameterInputs = ({ initialParams, sam, templateId, onChange }: Parameter
           ))}
         </div>
 
-        {templateId === 'korea-cge' && (
+        {(templateId === 'korea-cge' || templateId === 'saudi-cge') && (
           <div className="mt-6 space-y-4">
             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
               {sam.goods.map((sector, idx) => (

--- a/frontend/src/components/TemplateCard.tsx
+++ b/frontend/src/components/TemplateCard.tsx
@@ -35,6 +35,15 @@ const TemplateCard = ({ template, onSelect, isSelected, delay = 0 }: TemplateCar
             title="South Korea"
           />
         );
+      case 'saudi':
+        return (
+          <ReactCountryFlag
+            countryCode="SA"
+            svg
+            style={{ width: '1.2em', height: '1.2em' }}
+            title="Saudi Arabia"
+          />
+        );
       default:
         return '📄';
     }

--- a/frontend/src/screens/ModelBuilderPage.tsx
+++ b/frontend/src/screens/ModelBuilderPage.tsx
@@ -11,6 +11,7 @@ import {
   generateDefaultSam,
   generateEmptySam,
   generateKoreaSam,
+  generateSaudiSam,
   validateSam,
   exportSamToCsv,
   exportSamToExcel,
@@ -82,6 +83,15 @@ const ModelBuilderPage = () => {
         setUseCustomNames(false);
       } else if (selectedTemplate.id === 'korea-cge') {
         setSamData(generateKoreaSam());
+        setModelParameters({
+          alpha: [],
+          b: [],
+          tariff: [],
+          indirectTax: [],
+          incomeTax: []
+        });
+      } else if (selectedTemplate.id === 'saudi-cge') {
+        setSamData(generateSaudiSam());
         setModelParameters({
           alpha: [],
           b: [],

--- a/frontend/src/templates/template_descriptions.md
+++ b/frontend/src/templates/template_descriptions.md
@@ -73,6 +73,22 @@ If you're exploring themes like income inequality, structural change, or trade-d
 
 ---
 
+## 5. 🇸🇦 Saudi Arabia CGE Model (Oil-Driven Economy with Expat Labor)
+
+**Best for:** Resource-rich economies, subsidy analysis, labor market reforms
+
+**Key Features:**
+
+* Three sectors including oil and gas
+* Separate labor categories for Saudi nationals and expatriates
+* Government revenue from oil exports and domestic price subsidies
+* Tracks welfare of Saudi and expatriate households
+
+**Why choose this?**
+Ideal for studying policy changes in oil-dependent economies or the impact of migrant labor regulations.
+
+---
+
 Let your modeling goals guide your choice. If you're not sure where to start, we recommend beginning with the Simple CGE Model and gradually exploring more detailed templates as your needs evolve.
 
 > 🔧 **All templates are editable.** You can modify the number of goods, sectors, institutions, or behaviors to suit your analysis. You’re never locked into the structure of a chosen model.

--- a/frontend/src/utils/samUtils.ts
+++ b/frontend/src/utils/samUtils.ts
@@ -164,6 +164,17 @@ export const generateKoreaSam = (): SAM => {
   );
 };
 
+export const generateSaudiSam = (): SAM => {
+  return generateEmptySam(
+    3,
+    4,
+    2,
+    ['agricult', 'oilgas', 'tourism'],
+    ['CAP', 'saudi', 'unskilled-expat', 'skilled-expat'],
+    ['saudi-hh', 'expat-hh']
+  );
+};
+
 export const exportSamToCsv = (sam: SAM): string => {
   const headers = sam.entries;
   const rows = sam.data.map((row, index) => {

--- a/frontend/src/utils/templateData.ts
+++ b/frontend/src/utils/templateData.ts
@@ -60,6 +60,21 @@ const templates: ModelTemplate[] = [
       hasInvestment: true,
       description: 'Three sectors: agriculture, industry, and services. Two household types: labor-based and capital-based income'
     }
+  },
+  {
+    id: 'saudi-cge',
+    name: 'Saudi CGE Model',
+    shortDescription: 'Oil-driven economy with expatriate labor',
+    type: 'saudi',
+    sectors: ['agricult', 'oilgas', 'tourism'],
+    factors: ['CAP', 'saudi', 'unskilled-expat', 'skilled-expat'],
+    households: ['saudi-hh', 'expat-hh'],
+    details: {
+      hasGovernment: true,
+      hasTrade: true,
+      hasInvestment: true,
+      description: 'Three-sector model separating domestic and expatriate households with oil revenue.'
+    }
   }
 ];
 

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -3,7 +3,7 @@ export interface ModelTemplate {
   id: string;
   name: string;
   shortDescription: string;
-  type: 'simple' | 'standard' | 'cameroon' | 'korea';
+  type: 'simple' | 'standard' | 'cameroon' | 'korea' | 'saudi';
   sectors: string[];
   factors: string[];
   households: string[];

--- a/template_descriptions.md
+++ b/template_descriptions.md
@@ -73,6 +73,22 @@ If you're exploring themes like income inequality, structural change, or trade-d
 
 ---
 
+## 5. 🇸🇦 Saudi Arabia CGE Model (Oil-Driven Economy with Expat Labor)
+
+**Best for:** Resource-rich economies, subsidy analysis, labor market reforms
+
+**Key Features:**
+
+* Three sectors including oil and gas
+* Separate labor categories for Saudi nationals and expatriates
+* Government revenue from oil exports and domestic price subsidies
+* Tracks welfare of Saudi and expatriate households
+
+**Why choose this?**
+Ideal for studying policy changes in oil-dependent economies or the impact of migrant labor regulations.
+
+---
+
 Let your modeling goals guide your choice. If you're not sure where to start, we recommend beginning with the Simple CGE Model and gradually exploring more detailed templates as your needs evolve.
 
 > 🔧 **All templates are editable.** You can modify the number of goods, sectors, institutions, or behaviors to suit your analysis. You’re never locked into the structure of a chosen model.


### PR DESCRIPTION
## Summary
- support Saudi CGE model in backend and frontend
- document Saudi template
- update template metadata and parameter inputs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6869b5eb90b4832a8f5e4a27f09ca9dd