### PR TITLE
Add Saudi CGE model and scenario restrictions

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -257,6 +257,18 @@ def solve_model():
                 print(stack_trace)
                 return jsonify({'error': error_message, 'trace': stack_trace}), 500
 
+        elif template_id == 'saudi-cge':
+            try:
+                from models.model_wrappers import solve_saudi
+                results = solve_saudi()
+                return jsonify(results)
+            except Exception as sau_error:
+                error_message = f"Error solving Saudi model: {sau_error}"
+                stack_trace = traceback.format_exc()
+                print(error_message)
+                print(stack_trace)
+                return jsonify({'error': error_message, 'trace': stack_trace}), 500
+
         else:
             # For other templates (not implemented in MVP)
             return jsonify({
@@ -372,6 +384,7 @@ def compare_scenarios():
 
                 price_diffs = diff_dict(baseline_results['prices'], scenario_results['prices'])
                 prod_diffs = diff_dict(baseline_results['production'], scenario_results['production'])
+                fin_diffs = diff_dict(baseline_results['financials'], scenario_results['financials'])
 
                 util_diff = scenario_results['utility'] - baseline_results['utility']
                 util_pct = (util_diff / baseline_results['utility'] * 100) if baseline_results['utility'] else 0
@@ -385,12 +398,56 @@ def compare_scenarios():
                     'differences': {
                         'prices': price_diffs,
                         'production': prod_diffs,
+                        'financials': fin_diffs,
                         'utility': {'value': util_diff, 'percentChange': util_pct},
                         'gdp': {'value': gdp_diff, 'percentChange': gdp_pct},
                     }
                 })
             except Exception as kor_err:
                 error_message = f"Error comparing Korea scenarios: {kor_err}"
+                stack_trace = traceback.format_exc()
+                print(error_message)
+                print(stack_trace)
+                return jsonify({'error': error_message, 'trace': stack_trace}), 500
+
+        elif template_id == 'saudi-cge':
+            try:
+                from models.model_wrappers import solve_saudi
+                baseline_tariff = baseline_params.get('tariff')
+                baseline_itax = baseline_params.get('indirectTax')
+                baseline_htax = baseline_params.get('incomeTax')
+
+                scenario_tariff = scenario_params.get('tariff')
+                scenario_itax = scenario_params.get('indirectTax')
+                scenario_htax = scenario_params.get('incomeTax')
+
+                baseline_results = solve_saudi(baseline_tariff, baseline_itax, baseline_htax)
+                scenario_results = solve_saudi(scenario_tariff, scenario_itax, scenario_htax)
+
+                def diff_dict(base: Dict[str, float], other: Dict[str, float]):
+                    d = {}
+                    for k in base:
+                        b = float(base[k])
+                        o = float(other.get(k, 0))
+                        val = o - b
+                        pct = (val / b * 100) if b != 0 else 0
+                        d[k] = {'value': val, 'percentChange': pct}
+                    return d
+
+                fin_diffs = diff_dict(baseline_results['financials'], scenario_results['financials'])
+                gdp_diff = scenario_results['gdp'] - baseline_results['gdp']
+                gdp_pct = (gdp_diff / baseline_results['gdp'] * 100) if baseline_results['gdp'] else 0
+
+                return jsonify({
+                    'baseline': baseline_results,
+                    'scenario': scenario_results,
+                    'differences': {
+                        'financials': fin_diffs,
+                        'gdp': {'value': gdp_diff, 'percentChange': gdp_pct},
+                    }
+                })
+            except Exception as sau_err:
+                error_message = f"Error comparing Saudi scenarios: {sau_err}"
                 stack_trace = traceback.format_exc()
                 print(error_message)
                 print(stack_trace)

--- a/backend/models/model_wrappers.py
+++ b/backend/models/model_wrappers.py
@@ -1,28 +1,45 @@
 import importlib
 from typing import List, Optional, Dict
 
-from . import camcge, korcge
+from . import camcge, korcge, saudicge
 
 
 def _extract_results(container) -> Dict[str, float]:
-    """Extract common result metrics from a solved container."""
-    prices = container["px"].toDict()
-    production = container["xd"].toDict()
-    utility_var = container["omega"]
+    """Extract key results from a solved container."""
+    prices = container["px"].toDict() if "px" in container else {}
+    production = container["xd"].toDict() if "xd" in container else {}
+
+    utility_var = container.get("omega")
     utility = float(utility_var.toValue()) if utility_var is not None else 0.0
 
-    if "pva" in container and "xd" in container:
-        pva = container["pva"].toDict()
-        xd_vals = container["xd"].toDict()
-        gdp = sum(pva[s] * xd_vals.get(s, 0) for s in pva)
-    else:
-        gdp = sum(production.values())
+    # According to model specifications GDP equals the objective function value
+    gdp = utility
+
+    financials = {}
+    for var in [
+        "gr",
+        "tariff",
+        "indtax",
+        "netsub",
+        "invest",
+        "govsav",
+        "hhsav",
+        "fsav",
+        "fbor",
+        "tothhtax",
+    ]:
+        if var in container:
+            try:
+                financials[var] = float(container[var].toValue())
+            except Exception:
+                pass
 
     return {
         "prices": prices,
         "production": production,
         "utility": utility,
-        "gdp": float(gdp),
+        "gdp": gdp,
+        "financials": financials,
     }
 
 
@@ -41,6 +58,12 @@ def solve_korea(
     """Run the Korea CGE model with optional policy parameters."""
     mod = importlib.reload(korcge)
 
+    defaults = {
+        "tariff": [float(mod.tm[s]) for s in mod.data.sectors],
+        "indirectTax": [float(mod.itax[s]) for s in mod.data.sectors],
+        "incomeTax": [float(mod.htax[h]) for h in mod.data.households],
+    }
+
     if tariff is not None:
         for sec, val in zip(mod.data.sectors, tariff):
             mod.tm[sec] = float(val)
@@ -52,4 +75,36 @@ def solve_korea(
             mod.htax[hh] = float(val)
 
     mod.model1.solve(solver="CONOPT")
-    return _extract_results(mod.m)
+    results = _extract_results(mod.m)
+    results["params"] = defaults
+    return results
+
+
+def solve_saudi(
+    tariff: Optional[List[float]] = None,
+    indirect_tax: Optional[List[float]] = None,
+    income_tax: Optional[List[float]] = None,
+) -> Dict[str, float]:
+    """Run the Saudi CGE model with optional policy parameters."""
+    mod = importlib.reload(saudicge)
+
+    defaults = {
+        "tariff": [float(mod.tm[s]) for s in mod.data.sectors],
+        "indirectTax": [float(mod.itax[s]) for s in mod.data.sectors],
+        "incomeTax": [float(mod.htax[h]) for h in mod.data.households],
+    }
+
+    if tariff is not None:
+        for sec, val in zip(mod.data.sectors, tariff):
+            mod.tm[sec] = float(val)
+    if indirect_tax is not None:
+        for sec, val in zip(mod.data.sectors, indirect_tax):
+            mod.itax[sec] = float(val)
+    if income_tax is not None:
+        for hh, val in zip(mod.data.households, income_tax):
+            mod.htax[hh] = float(val)
+
+    mod.model1.solve(solver="CONOPT")
+    results = _extract_results(mod.m)
+    results["params"] = defaults
+    return results

--- a/frontend/src/components/ComparisonDisplay.tsx
+++ b/frontend/src/components/ComparisonDisplay.tsx
@@ -6,19 +6,40 @@ interface ComparisonDisplayProps {
 }
 
 const ComparisonDisplay = ({ comparison }: ComparisonDisplayProps) => {
-  // Prepare data for the percentage change chart
-  const percentChangeData = Object.entries(comparison.differences.prices).map(([key, data]) => ({
-    name: key,
-    price: data.percentChange,
-    production: comparison.differences.production[key]?.percentChange || 0
-  }));
+  const percentChangeData = comparison.differences.financials
+    ? Object.entries(comparison.differences.financials).map(([k, v]) => ({ name: k, change: v.percentChange }))
+    : [];
 
-  // Prepare data for side-by-side comparison chart
-  const comparisonData = Object.entries(comparison.baseline.production).map(([key, value]) => ({
-    name: key,
-    baseline: value,
-    scenario: comparison.scenario.production[key] || 0
-  }));
+  const comparisonData = comparison.differences.financials
+    ? Object.entries(comparison.differences.financials).map(([k, v]) => ({
+        name: k,
+        baseline: comparison.baseline.financials?.[k] || 0,
+        scenario: comparison.scenario.financials?.[k] || 0,
+      }))
+    : [];
+
+  const downloadCsv = () => {
+    const rows = [
+      ['Indicator', 'Baseline', 'Scenario', '% Change'],
+      ...Object.entries(comparison.differences.financials || {}).map(([k, v]) => [
+        k,
+        (comparison.baseline.financials?.[k] || 0).toFixed(2),
+        (comparison.scenario.financials?.[k] || 0).toFixed(2),
+        v.percentChange.toFixed(2),
+      ]),
+      ['GDP', comparison.baseline.gdp.toFixed(2), comparison.scenario.gdp.toFixed(2), comparison.differences.gdp.percentChange.toFixed(2)],
+    ];
+    const csv = rows.map(r => r.join(',')).join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', 'comparison.csv');
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
 
   return (
     <div className="p-4 bg-white rounded-lg shadow-sm">
@@ -38,136 +59,73 @@ const ComparisonDisplay = ({ comparison }: ComparisonDisplayProps) => {
                 </tr>
               </thead>
               <tbody className="bg-white divide-y divide-midgray/30">
+                {Object.entries(comparison.differences.financials || {}).map(([k, v]) => (
+                  <tr key={k}>
+                    <td className="px-2 py-1 whitespace-nowrap text-sm font-medium text-darkgray">{k}</td>
+                    <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{(comparison.baseline.financials?.[k] || 0).toFixed(2)}</td>
+                    <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{(comparison.scenario.financials?.[k] || 0).toFixed(2)}</td>
+                    <td className={`px-2 py-1 whitespace-nowrap text-sm text-right ${
+                      v.percentChange > 0 ? 'text-success' : v.percentChange < 0 ? 'text-warning' : 'text-darkgray'
+                    }`}>
+                      {v.percentChange.toFixed(2)}%
+                    </td>
+                  </tr>
+                ))}
                 <tr>
                   <td className="px-2 py-1 whitespace-nowrap text-sm font-medium text-darkgray">GDP</td>
                   <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{comparison.baseline.gdp.toFixed(2)}</td>
                   <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{comparison.scenario.gdp.toFixed(2)}</td>
                   <td className={`px-2 py-1 whitespace-nowrap text-sm text-right ${
-                    comparison.differences.gdp.percentChange > 0 
-                      ? 'text-success' 
-                      : comparison.differences.gdp.percentChange < 0 
-                        ? 'text-warning' 
-                        : 'text-darkgray'
+                    comparison.differences.gdp.percentChange > 0 ? 'text-success' : comparison.differences.gdp.percentChange < 0 ? 'text-warning' : 'text-darkgray'
                   }`}>
                     {comparison.differences.gdp.percentChange.toFixed(2)}%
-                  </td>
-                </tr>
-                <tr>
-                  <td className="px-2 py-1 whitespace-nowrap text-sm font-medium text-darkgray">Utility</td>
-                  <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{comparison.baseline.utility.toFixed(2)}</td>
-                  <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{comparison.scenario.utility.toFixed(2)}</td>
-                  <td className={`px-2 py-1 whitespace-nowrap text-sm text-right ${
-                    comparison.differences.utility.percentChange > 0 
-                      ? 'text-success' 
-                      : comparison.differences.utility.percentChange < 0 
-                        ? 'text-warning' 
-                        : 'text-darkgray'
-                  }`}>
-                    {comparison.differences.utility.percentChange.toFixed(2)}%
                   </td>
                 </tr>
               </tbody>
             </table>
           </div>
         </div>
-        
+
         <div className="card">
           <h4 className="text-md font-medium mb-2">Percentage Changes</h4>
           <div className="h-48">
             <ResponsiveContainer width="100%" height="100%">
-              <BarChart
-                data={percentChangeData}
-                margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
-              >
+              <BarChart data={percentChangeData} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis dataKey="name" />
                 <YAxis unit="%" />
                 <Tooltip formatter={(value: number) => `${value.toFixed(2)}%`} />
                 <Legend />
-                <Bar dataKey="price" fill="#f97316" name="Price" />
-                <Bar dataKey="production" fill="#3b82f6" name="Production" />
+                <Bar dataKey="change" fill="#3b82f6" name="% Change" />
               </BarChart>
             </ResponsiveContainer>
           </div>
         </div>
       </div>
       
-      <div className="mt-6">
-        <h4 className="text-md font-medium mb-2">Production Comparison</h4>
-        <div className="h-64">
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={comparisonData}
-              margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
-            >
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" />
-              <YAxis />
-              <Tooltip />
-              <Legend />
-              <Bar dataKey="baseline" fill="#3b82f6" name="Baseline" />
-              <Bar dataKey="scenario" fill="#10b981" name="Scenario" />
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
-      </div>
-      
-      <div className="mt-6">
-        <h4 className="text-md font-medium mb-2">Detailed Changes</h4>
-        <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-midgray/30">
-            <thead>
-              <tr>
-                <th className="px-2 py-1 text-left text-xs font-medium text-darkgray/70 uppercase tracking-wider">Good</th>
-                <th className="px-2 py-1 text-right text-xs font-medium text-darkgray/70 uppercase tracking-wider">Baseline Price</th>
-                <th className="px-2 py-1 text-right text-xs font-medium text-darkgray/70 uppercase tracking-wider">Scenario Price</th>
-                <th className="px-2 py-1 text-right text-xs font-medium text-darkgray/70 uppercase tracking-wider">Price % Change</th>
-                <th className="px-2 py-1 text-right text-xs font-medium text-darkgray/70 uppercase tracking-wider">Baseline Prod.</th>
-                <th className="px-2 py-1 text-right text-xs font-medium text-darkgray/70 uppercase tracking-wider">Scenario Prod.</th>
-                <th className="px-2 py-1 text-right text-xs font-medium text-darkgray/70 uppercase tracking-wider">Prod. % Change</th>
-              </tr>
-            </thead>
-            <tbody className="bg-white divide-y divide-midgray/30">
-              {Object.entries(comparison.baseline.prices).map(([key, baselinePrice]) => {
-                const scenarioPrice = comparison.scenario.prices[key] || 0;
-                const priceChange = comparison.differences.prices[key]?.percentChange || 0;
-                
-                const baselineProd = comparison.baseline.production[key] || 0;
-                const scenarioProd = comparison.scenario.production[key] || 0;
-                const prodChange = comparison.differences.production[key]?.percentChange || 0;
-                
-                return (
-                  <tr key={key}>
-                    <td className="px-2 py-1 whitespace-nowrap text-sm font-medium text-darkgray">{key}</td>
-                    <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{baselinePrice.toFixed(2)}</td>
-                    <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{scenarioPrice.toFixed(2)}</td>
-                    <td className={`px-2 py-1 whitespace-nowrap text-sm text-right ${
-                      priceChange > 0 
-                        ? 'text-success' 
-                        : priceChange < 0 
-                          ? 'text-warning' 
-                          : 'text-darkgray'
-                    }`}>
-                      {priceChange.toFixed(2)}%
-                    </td>
-                    <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{baselineProd.toFixed(2)}</td>
-                    <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{scenarioProd.toFixed(2)}</td>
-                    <td className={`px-2 py-1 whitespace-nowrap text-sm text-right ${
-                      prodChange > 0 
-                        ? 'text-success' 
-                        : prodChange < 0 
-                          ? 'text-warning' 
-                          : 'text-darkgray'
-                    }`}>
-                      {prodChange.toFixed(2)}%
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      </div>
+      {comparisonData.length > 0 && (
+        <>
+          <div className="mt-6">
+            <h4 className="text-md font-medium mb-2">Financial Comparison</h4>
+            <div className="h-64">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={comparisonData} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="name" />
+                  <YAxis />
+                  <Tooltip />
+                  <Legend />
+                  <Bar dataKey="baseline" fill="#3b82f6" name="Baseline" />
+                  <Bar dataKey="scenario" fill="#10b981" name="Scenario" />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+          <div className="mt-4">
+            <button onClick={downloadCsv} className="btn btn-primary">Download CSV</button>
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/ParameterInputs.tsx
+++ b/frontend/src/components/ParameterInputs.tsx
@@ -43,7 +43,7 @@ const ParameterInputs = ({ initialParams, sam, templateId, onChange }: Parameter
       );
       setBValues(defaultB);
 
-      if (templateId === 'korea-cge') {
+      if (templateId === 'korea-cge' || templateId === 'saudi-cge') {
         const defTariff = sam.goods.map((_, i) => initialParams?.tariff?.[i] ?? 0);
         const defIndirect = sam.goods.map((_, i) => initialParams?.indirectTax?.[i] ?? 0);
         setTariffValues(defTariff);
@@ -68,7 +68,7 @@ const ParameterInputs = ({ initialParams, sam, templateId, onChange }: Parameter
         alpha: alphaValues,
         b: bValues
       };
-      if (templateId === 'korea-cge') {
+      if (templateId === 'korea-cge' || templateId === 'saudi-cge') {
         params.tariff = tariffValues;
         params.indirectTax = indirectValues;
         params.incomeTax = incomeValues;
@@ -99,7 +99,8 @@ const ParameterInputs = ({ initialParams, sam, templateId, onChange }: Parameter
 
   return (
     <div className="p-4 bg-white rounded-lg shadow-sm">
-      
+
+      {templateId !== 'korea-cge' && templateId !== 'saudi-cge' && (
       <div className="mb-6">
         <h4 className="text-md font-medium mb-2">Utility Function Parameters (Alpha)</h4>
         <p className="text-sm text-darkgray/70 mb-4">
@@ -129,7 +130,9 @@ const ParameterInputs = ({ initialParams, sam, templateId, onChange }: Parameter
           Note: Sum of Alpha values should ideally be 1.0 for proper model behavior.
         </div>
       </div>
-      
+      )}
+
+      {templateId !== 'korea-cge' && templateId !== 'saudi-cge' && (
       <div>
         <h4 className="text-md font-medium mb-2">Production Function Parameters (B)</h4>
         <p className="text-sm text-darkgray/70 mb-4">
@@ -153,67 +156,69 @@ const ParameterInputs = ({ initialParams, sam, templateId, onChange }: Parameter
             </div>
           ))}
         </div>
+      </div>
+      )}
 
-        {templateId === 'korea-cge' && (
-          <div className="mt-6 space-y-4">
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-              {sam.goods.map((sector, idx) => (
-                <div key={`tar-${idx}`} className="flex flex-col">
-                  <label className="text-sm font-medium mb-1">{sector} Tariff</label>
-                  <input
-                    type="number"
-                    step="0.01"
-                    value={tariffValues[idx] || 0}
-                    onChange={(e) => {
-                      const v = [...tariffValues];
-                      v[idx] = parseFloat(e.target.value) || 0;
-                      setTariffValues(v);
-                    }}
-                    className="input"
-                  />
-                </div>
-              ))}
-            </div>
-
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-              {sam.goods.map((sector, idx) => (
-                <div key={`ind-${idx}`} className="flex flex-col">
-                  <label className="text-sm font-medium mb-1">{sector} Indirect Tax</label>
-                  <input
-                    type="number"
-                    step="0.01"
-                    value={indirectValues[idx] || 0}
-                    onChange={(e) => {
-                      const v = [...indirectValues];
-                      v[idx] = parseFloat(e.target.value) || 0;
-                      setIndirectValues(v);
-                    }}
-                    className="input"
-                  />
-                </div>
-              ))}
-            </div>
-
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-              {sam.households.map((hh, idx) => (
-                <div key={`inc-${idx}`} className="flex flex-col">
-                  <label className="text-sm font-medium mb-1">{hh} Income Tax</label>
-                  <input
-                    type="number"
-                    step="0.01"
-                    value={incomeValues[idx] || 0}
-                    onChange={(e) => {
-                      const v = [...incomeValues];
-                      v[idx] = parseFloat(e.target.value) || 0;
-                      setIncomeValues(v);
-                    }}
-                    className="input"
-                  />
-                </div>
-              ))}
-            </div>
+      {(templateId === 'korea-cge' || templateId === 'saudi-cge') && (
+        <div className="mt-6 space-y-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+            {sam.goods.map((sector, idx) => (
+              <div key={`tar-${idx}`} className="flex flex-col">
+                <label className="text-sm font-medium mb-1">{sector} Tariff</label>
+                <input
+                  type="number"
+                  step="0.01"
+                  value={tariffValues[idx] || 0}
+                  onChange={(e) => {
+                    const v = [...tariffValues];
+                    v[idx] = parseFloat(e.target.value) || 0;
+                    setTariffValues(v);
+                  }}
+                  className="input"
+                />
+              </div>
+            ))}
           </div>
-        )}
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+            {sam.goods.map((sector, idx) => (
+              <div key={`ind-${idx}`} className="flex flex-col">
+                <label className="text-sm font-medium mb-1">{sector} Indirect Tax</label>
+                <input
+                  type="number"
+                  step="0.01"
+                  value={indirectValues[idx] || 0}
+                  onChange={(e) => {
+                    const v = [...indirectValues];
+                    v[idx] = parseFloat(e.target.value) || 0;
+                    setIndirectValues(v);
+                  }}
+                  className="input"
+                />
+              </div>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+            {sam.households.map((hh, idx) => (
+              <div key={`inc-${idx}`} className="flex flex-col">
+                <label className="text-sm font-medium mb-1">{hh} Income Tax</label>
+                <input
+                  type="number"
+                  step="0.01"
+                  value={incomeValues[idx] || 0}
+                  onChange={(e) => {
+                    const v = [...incomeValues];
+                    v[idx] = parseFloat(e.target.value) || 0;
+                    setIncomeValues(v);
+                  }}
+                  className="input"
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
       </div>
     </div>
   );

--- a/frontend/src/components/ResultsDisplay.tsx
+++ b/frontend/src/components/ResultsDisplay.tsx
@@ -4,19 +4,24 @@ import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, Responsive
 interface ResultsDisplayProps {
   results: ModelResults;
   title?: string;
+  templateId?: string;
 }
 
-const ResultsDisplay = ({ results, title = 'Model Results' }: ResultsDisplayProps) => {
+const ResultsDisplay = ({ results, title = 'Model Results', templateId }: ResultsDisplayProps) => {
   // Format data for charts
-  const priceChartData = Object.entries(results.prices).map(([key, value]) => ({
+  const priceChartData = Object.entries(results.prices || {}).map(([key, value]) => ({
     name: key,
     price: value
   }));
 
-  const productionChartData = Object.entries(results.production).map(([key, value]) => ({
+  const productionChartData = Object.entries(results.production || {}).map(([key, value]) => ({
     name: key,
     production: value
   }));
+
+  const financialChartData = results.financials
+    ? Object.entries(results.financials).map(([k, v]) => ({ name: k, value: v }))
+    : [];
 
   return (
     <div className="p-4 bg-white rounded-lg shadow-sm">
@@ -37,66 +42,94 @@ const ResultsDisplay = ({ results, title = 'Model Results' }: ResultsDisplayProp
           </div>
         </div>
         
-        <div className="card">
-          <h4 className="text-md font-medium mb-2">Prices</h4>
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-midgray/30">
-              <thead>
-                <tr>
-                  <th className="px-2 py-1 text-left text-xs font-medium text-darkgray/70 uppercase tracking-wider">Good</th>
-                  <th className="px-2 py-1 text-right text-xs font-medium text-darkgray/70 uppercase tracking-wider">Price</th>
-                </tr>
-              </thead>
-              <tbody className="bg-white divide-y divide-midgray/30">
-                {Object.entries(results.prices).map(([key, value]) => (
-                  <tr key={key}>
-                    <td className="px-2 py-1 whitespace-nowrap text-sm font-medium text-darkgray">{key}</td>
-                    <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{value.toFixed(2)}</td>
+        {results.financials ? (
+          <div className="card">
+            <h4 className="text-md font-medium mb-2">Financial Indicators</h4>
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-midgray/30">
+                <thead>
+                  <tr>
+                    <th className="px-2 py-1 text-left text-xs font-medium text-darkgray/70 uppercase tracking-wider">Item</th>
+                    <th className="px-2 py-1 text-right text-xs font-medium text-darkgray/70 uppercase tracking-wider">Value</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody className="bg-white divide-y divide-midgray/30">
+                  {Object.entries(results.financials).map(([k, v]) => (
+                    <tr key={k}>
+                      <td className="px-2 py-1 whitespace-nowrap text-sm font-medium text-darkgray">{k}</td>
+                      <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{v.toFixed(2)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </div>
-        </div>
+        ) : (
+          <div className="card">
+            <h4 className="text-md font-medium mb-2">Prices</h4>
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-midgray/30">
+                <thead>
+                  <tr>
+                    <th className="px-2 py-1 text-left text-xs font-medium text-darkgray/70 uppercase tracking-wider">Good</th>
+                    <th className="px-2 py-1 text-right text-xs font-medium text-darkgray/70 uppercase tracking-wider">Price</th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y divide-midgray/30">
+                  {Object.entries(results.prices).map(([key, value]) => (
+                    <tr key={key}>
+                      <td className="px-2 py-1 whitespace-nowrap text-sm font-medium text-darkgray">{key}</td>
+                      <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{value.toFixed(2)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
       </div>
-      
-      <div className="mt-6">
-        <h4 className="text-md font-medium mb-2">Production by Sector</h4>
-        <div className="h-64">
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={productionChartData}
-              margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
-            >
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" />
-              <YAxis />
-              <Tooltip />
-              <Legend />
-              <Bar dataKey="production" fill="#3b82f6" name="Production" />
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
-      </div>
-      
-      <div className="mt-6">
-        <h4 className="text-md font-medium mb-2">Prices by Sector</h4>
-        <div className="h-64">
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={priceChartData}
-              margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
-            >
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" />
-              <YAxis />
-              <Tooltip />
-              <Legend />
-              <Bar dataKey="price" fill="#f97316" name="Price" />
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
-      </div>
+
+      {!results.financials && (
+        <>
+          <div className="mt-6">
+            <h4 className="text-md font-medium mb-2">Production by Sector</h4>
+            <div className="h-64">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart
+                  data={productionChartData}
+                  margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="name" />
+                  <YAxis />
+                  <Tooltip />
+                  <Legend />
+                  <Bar dataKey="production" fill="#3b82f6" name="Production" />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+
+          <div className="mt-6">
+            <h4 className="text-md font-medium mb-2">Prices by Sector</h4>
+            <div className="h-64">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart
+                  data={priceChartData}
+                  margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="name" />
+                  <YAxis />
+                  <Tooltip />
+                  <Legend />
+                  <Bar dataKey="price" fill="#f97316" name="Price" />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/frontend/src/screens/ModelBuilderPage.tsx
+++ b/frontend/src/screens/ModelBuilderPage.tsx
@@ -11,6 +11,7 @@ import {
   generateDefaultSam,
   generateEmptySam,
   generateKoreaSam,
+  generateSaudiSam,
   validateSam,
   exportSamToCsv,
   exportSamToExcel,
@@ -82,6 +83,15 @@ const ModelBuilderPage = () => {
         setUseCustomNames(false);
       } else if (selectedTemplate.id === 'korea-cge') {
         setSamData(generateKoreaSam());
+        setModelParameters({
+          alpha: [],
+          b: [],
+          tariff: [],
+          indirectTax: [],
+          incomeTax: []
+        });
+      } else if (selectedTemplate.id === 'saudi-cge') {
+        setSamData(generateSaudiSam());
         setModelParameters({
           alpha: [],
           b: [],
@@ -360,7 +370,10 @@ const ModelBuilderPage = () => {
       // Call the API to solve the model
       const templateId = selectedTemplate?.id || 'simple-cge';
       const results = await solveModel(templateId, modelParameters, isCustomSam ? samData : undefined);
-      
+
+      if (results.params) {
+        setModelParameters({ ...modelParameters, ...results.params });
+      }
       setModelResults(results);
       setCurrentStep(4);
     } catch (err) {
@@ -850,7 +863,7 @@ const ModelBuilderPage = () => {
         <div>
           <h2 className="text-2xl font-semibold mb-6">Model Results</h2>
           
-          <ResultsDisplay results={modelResults} />
+          <ResultsDisplay results={modelResults} templateId={selectedTemplate?.id} />
           
           <div className="bg-white rounded-lg shadow-sm p-6 mt-8">
             <h3 className="text-xl font-medium mb-4">What would you like to do next?</h3>

--- a/frontend/src/utils/samUtils.ts
+++ b/frontend/src/utils/samUtils.ts
@@ -164,6 +164,17 @@ export const generateKoreaSam = (): SAM => {
   );
 };
 
+export const generateSaudiSam = (): SAM => {
+  return generateEmptySam(
+    3,
+    2,
+    2,
+    ['agricult', 'oilgas', 'tourism'],
+    ['CAP', 'LAB'],
+    ['saudi-hh', 'expat-hh']
+  );
+};
+
 export const exportSamToCsv = (sam: SAM): string => {
   const headers = sam.entries;
   const rows = sam.data.map((row, index) => {

--- a/frontend/src/utils/templateData.ts
+++ b/frontend/src/utils/templateData.ts
@@ -60,6 +60,21 @@ const templates: ModelTemplate[] = [
       hasInvestment: true,
       description: 'Three sectors: agriculture, industry, and services. Two household types: labor-based and capital-based income'
     }
+  },
+  {
+    id: 'saudi-cge',
+    name: 'Saudi CGE Model',
+    shortDescription: 'Energy dependent economy with expat labor considerations',
+    type: 'korea',
+    sectors: ['agricult', 'oilgas', 'tourism'],
+    factors: ['CAP', 'LAB'],
+    households: ['saudi-hh', 'expat-hh'],
+    details: {
+      hasGovernment: true,
+      hasTrade: true,
+      hasInvestment: true,
+      description: 'Three sector Saudi economy with two household types.'
+    }
   }
 ];
 

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -43,6 +43,14 @@ export interface ModelResults {
   };
   utility: number;
   gdp: number;
+  financials?: {
+    [key: string]: number;
+  };
+  params?: {
+    tariff?: number[];
+    indirectTax?: number[];
+    incomeTax?: number[];
+  };
 }
 
 // Scenario Comparison
@@ -57,6 +65,12 @@ export interface ScenarioComparison {
       };
     };
     production: {
+      [key: string]: {
+        value: number;
+        percentChange: number;
+      };
+    };
+    financials?: {
       [key: string]: {
         value: number;
         percentChange: number;


### PR DESCRIPTION
## Summary
- support Saudi CGE model alongside Korea model
- expose tariff and tax defaults from backend wrappers
- limit scenario inputs to tariff and tax rates
- return financial metrics and show them in results
- compare scenarios using monetary metrics

## Testing
- `npm run lint` *(fails: ESLint couldn't find plugin)*
- `pytest -q` *(fails: ModuleNotFoundError: requests)*

------
https://chatgpt.com/codex/tasks/task_e_6869b815e668832aa8ad02664472a093