### PR TITLE
Fix ParameterInputs JSX closure

### DIFF
--- a/frontend/src/components/ParameterInputs.tsx
+++ b/frontend/src/components/ParameterInputs.tsx
@@ -219,7 +219,6 @@ const ParameterInputs = ({ initialParams, sam, templateId, onChange }: Parameter
           </div>
         </div>
       )}
-      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- fix mismatched JSX tag in ParameterInputs component

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_6869bcb6cb80832a9311e713f5a7727c