### PR TITLE
Add units for financials and reorder templates

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -373,14 +373,14 @@ def compare_scenarios():
                 baseline_results = solve_korea(baseline_tariff, baseline_itax, baseline_htax)
                 scenario_results = solve_korea(scenario_tariff, scenario_itax, scenario_htax)
 
-                def diff_dict(base: Dict[str, float], other: Dict[str, float]):
+                def diff_dict(base: Dict[str, Dict[str, float]], other: Dict[str, Dict[str, float]]):
                     d = {}
                     for k in base:
-                        b = float(base[k])
-                        o = float(other.get(k, 0))
+                        b = float(base[k].get('value', 0))
+                        o = float(other.get(k, {}).get('value', 0))
                         val = o - b
                         pct = (val / b * 100) if b != 0 else 0
-                        d[k] = {'value': val, 'percentChange': pct}
+                        d[k] = {'value': val, 'percentChange': pct, 'unit': base[k].get('unit', '')}
                     return d
 
                 price_diffs = diff_dict(baseline_results['prices'], scenario_results['prices'])
@@ -425,14 +425,14 @@ def compare_scenarios():
                 baseline_results = solve_saudi(baseline_tariff, baseline_itax, baseline_htax)
                 scenario_results = solve_saudi(scenario_tariff, scenario_itax, scenario_htax)
 
-                def diff_dict(base: Dict[str, float], other: Dict[str, float]):
+                def diff_dict(base: Dict[str, Dict[str, float]], other: Dict[str, Dict[str, float]]):
                     d = {}
                     for k in base:
-                        b = float(base[k])
-                        o = float(other.get(k, 0))
+                        b = float(base[k].get('value', 0))
+                        o = float(other.get(k, {}).get('value', 0))
                         val = o - b
                         pct = (val / b * 100) if b != 0 else 0
-                        d[k] = {'value': val, 'percentChange': pct}
+                        d[k] = {'value': val, 'percentChange': pct, 'unit': base[k].get('unit', '')}
                     return d
 
                 fin_diffs = diff_dict(baseline_results['financials'], scenario_results['financials'])

--- a/backend/models/model_wrappers.py
+++ b/backend/models/model_wrappers.py
@@ -5,7 +5,7 @@ from . import camcge, korcge, saudicge
 
 
 def _extract_results(container) -> Dict[str, float]:
-    """Extract key results from a solved container."""
+    """Extract key results from a solved container along with units."""
     prices = container["px"].toDict() if "px" in container else {}
     production = container["xd"].toDict() if "xd" in container else {}
 
@@ -30,7 +30,10 @@ def _extract_results(container) -> Dict[str, float]:
     ]:
         if var in container:
             try:
-                financials[var] = float(container[var].toValue())
+                val = float(container[var].toValue())
+                desc = getattr(container[var], "description", "")
+                unit = desc.split("(")[-1].rstrip(")") if "(" in desc else ""
+                financials[var] = {"value": val, "unit": unit}
             except Exception:
                 pass
 

--- a/frontend/src/components/ComparisonDisplay.tsx
+++ b/frontend/src/components/ComparisonDisplay.tsx
@@ -13,8 +13,9 @@ const ComparisonDisplay = ({ comparison }: ComparisonDisplayProps) => {
   const comparisonData = comparison.differences.financials
     ? Object.entries(comparison.differences.financials).map(([k, v]) => ({
         name: k,
-        baseline: comparison.baseline.financials?.[k] || 0,
-        scenario: comparison.scenario.financials?.[k] || 0,
+        baseline: comparison.baseline.financials?.[k]?.value || 0,
+        scenario: comparison.scenario.financials?.[k]?.value || 0,
+        unit: comparison.baseline.financials?.[k]?.unit || ''
       }))
     : [];
 
@@ -23,8 +24,8 @@ const ComparisonDisplay = ({ comparison }: ComparisonDisplayProps) => {
       ['Indicator', 'Baseline', 'Scenario', '% Change'],
       ...Object.entries(comparison.differences.financials || {}).map(([k, v]) => [
         k,
-        (comparison.baseline.financials?.[k] || 0).toFixed(2),
-        (comparison.scenario.financials?.[k] || 0).toFixed(2),
+        (comparison.baseline.financials?.[k]?.value || 0).toFixed(2),
+        (comparison.scenario.financials?.[k]?.value || 0).toFixed(2),
         v.percentChange.toFixed(2),
       ]),
       ['GDP', comparison.baseline.gdp.toFixed(2), comparison.scenario.gdp.toFixed(2), comparison.differences.gdp.percentChange.toFixed(2)],
@@ -62,8 +63,12 @@ const ComparisonDisplay = ({ comparison }: ComparisonDisplayProps) => {
                 {Object.entries(comparison.differences.financials || {}).map(([k, v]) => (
                   <tr key={k}>
                     <td className="px-2 py-1 whitespace-nowrap text-sm font-medium text-darkgray">{k}</td>
-                    <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{(comparison.baseline.financials?.[k] || 0).toFixed(2)}</td>
-                    <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{(comparison.scenario.financials?.[k] || 0).toFixed(2)}</td>
+                    <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">
+                      {(comparison.baseline.financials?.[k]?.value || 0).toFixed(2)} {comparison.baseline.financials?.[k]?.unit}
+                    </td>
+                    <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">
+                      {(comparison.scenario.financials?.[k]?.value || 0).toFixed(2)} {comparison.scenario.financials?.[k]?.unit}
+                    </td>
                     <td className={`px-2 py-1 whitespace-nowrap text-sm text-right ${
                       v.percentChange > 0 ? 'text-success' : v.percentChange < 0 ? 'text-warning' : 'text-darkgray'
                     }`}>

--- a/frontend/src/components/ResultsDisplay.tsx
+++ b/frontend/src/components/ResultsDisplay.tsx
@@ -20,7 +20,7 @@ const ResultsDisplay = ({ results, title = 'Model Results', templateId }: Result
   }));
 
   const financialChartData = results.financials
-    ? Object.entries(results.financials).map(([k, v]) => ({ name: k, value: v }))
+    ? Object.entries(results.financials).map(([k, v]) => ({ name: k, value: v.value }))
     : [];
 
   return (
@@ -57,7 +57,9 @@ const ResultsDisplay = ({ results, title = 'Model Results', templateId }: Result
                   {Object.entries(results.financials).map(([k, v]) => (
                     <tr key={k}>
                       <td className="px-2 py-1 whitespace-nowrap text-sm font-medium text-darkgray">{k}</td>
-                      <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{v.toFixed(2)}</td>
+                      <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">
+                        {v.value.toFixed(2)} {v.unit}
+                      </td>
                     </tr>
                   ))}
                 </tbody>

--- a/frontend/src/templates/template_descriptions.md
+++ b/frontend/src/templates/template_descriptions.md
@@ -23,24 +23,8 @@ This model is ideal for beginners or classroom settings. It helps users understa
 
 ---
 
-## 2. 📊 Standard CGE Model (Full Domestic Economy with Taxes & Trade)
 
-**Best for:** Policy simulations, national-level planning, intermediate users
-
-**Key Features:**
-
-* Includes taxes, government, savings, investment, and foreign sector
-* Models intermediate inputs, factor markets, and production taxes
-* Armington function for imports and CET for exports
-* Household consumption, government spending, and capital formation all modeled
-* Output: Changes in prices, outputs, trade flows, and welfare indicators (e.g., EV)
-
-**Why choose this?**
-If you’re looking to analyze real-world policy issues like tariffs, tax changes, or foreign shocks, this is your go-to model. It offers rich structure while staying manageable. It’s perfect for applied research, consulting work, or pilot policy analysis.
-
----
-
-## 3. 🇨🇲 Cameroon CGE Model (Detailed Sectoral Model for a Developing Economy)
+## 2. 🇨🇲 Cameroon CGE Model (Detailed Sectoral Model for a Developing Economy)
 
 **Best for:** Sectoral studies, development planning, researchers working on African economies
 
@@ -56,7 +40,7 @@ This is a country-specific model template inspired by the World Bank framework, 
 
 ---
 
-## 4. 🇰🇷 Korea CGE Model (3-Sector Economy with Household Types)
+## 3. 🇰🇷 Korea CGE Model (3-Sector Economy with Household Types)
 
 **Best for:** Studying economic transformation, industrialization, or equity
 
@@ -73,7 +57,7 @@ If you're exploring themes like income inequality, structural change, or trade-d
 
 ---
 
-## 5. 🇸🇦 Saudi Arabia CGE Model (Oil-Driven Economy with Expat Labor)
+## 4. 🇸🇦 Saudi Arabia CGE Model (Oil-Driven Economy with Expat Labor)
 
 **Best for:** Resource-rich economies, subsidy analysis, labor market reforms
 
@@ -86,6 +70,22 @@ If you're exploring themes like income inequality, structural change, or trade-d
 
 **Why choose this?**
 Ideal for studying policy changes in oil-dependent economies or the impact of migrant labor regulations.
+
+---
+## 5. 📊 Standard CGE Model (Full Domestic Economy with Taxes & Trade)
+
+**Best for:** Policy simulations, national-level planning, intermediate users
+
+**Key Features:**
+
+* Includes taxes, government, savings, investment, and foreign sector
+* Models intermediate inputs, factor markets, and production taxes
+* Armington function for imports and CET for exports
+* Household consumption, government spending, and capital formation all modeled
+* Output: Changes in prices, outputs, trade flows, and welfare indicators (e.g., EV)
+
+**Why choose this?**
+If you’re looking to analyze real-world policy issues like tariffs, tax changes, or foreign shocks, this is your go-to model. It offers rich structure while staying manageable. It’s perfect for applied research, consulting work, or pilot policy analysis.
 
 ---
 

--- a/frontend/src/utils/templateData.ts
+++ b/frontend/src/utils/templateData.ts
@@ -17,21 +17,6 @@ const templates: ModelTemplate[] = [
     }
   },
   {
-    id: 'standard-cge',
-    name: 'Standard CGE Model',
-    shortDescription: 'Policy simulations, national-level planning, intermediate users',
-    type: 'standard',
-    sectors: ['AGR', 'MFG', 'SVC'],
-    factors: ['CAP', 'LAB', 'LAND'],
-    households: ['HOH'],
-    details: {
-      hasGovernment: true,
-      hasTrade: true,
-      hasInvestment: true,
-      description: 'Includes taxes, government, savings, investment, and foreign sector'
-    }
-  },
-  {
     id: 'cameroon-cge',
     name: 'Cameroon CGE Model',
     shortDescription: 'Sectoral studies, development planning, African economies',
@@ -74,6 +59,22 @@ const templates: ModelTemplate[] = [
       hasTrade: true,
       hasInvestment: true,
       description: 'Three sector Saudi economy with two household types.'
+    }
+  }
+  ,
+  {
+    id: 'standard-cge',
+    name: 'Standard CGE Model',
+    shortDescription: 'Policy simulations, national-level planning, intermediate users',
+    type: 'standard',
+    sectors: ['AGR', 'MFG', 'SVC'],
+    factors: ['CAP', 'LAB', 'LAND'],
+    households: ['HOH'],
+    details: {
+      hasGovernment: true,
+      hasTrade: true,
+      hasInvestment: true,
+      description: 'Includes taxes, government, savings, investment, and foreign sector'
     }
   }
 ];

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -44,7 +44,10 @@ export interface ModelResults {
   utility: number;
   gdp: number;
   financials?: {
-    [key: string]: number;
+    [key: string]: {
+      value: number;
+      unit?: string;
+    };
   };
   params?: {
     tariff?: number[];
@@ -74,6 +77,7 @@ export interface ScenarioComparison {
       [key: string]: {
         value: number;
         percentChange: number;
+        unit?: string;
       };
     };
     utility: {


### PR DESCRIPTION
## Summary
- include units for financial indicators in Korea and Saudi models
- surface these units in results and comparison displays
- move Standard template to bottom of template list and update descriptions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6869bdeb18bc832a8ef960fa2dde82f8