### PR TITLE
Fix Saudi template flag

### DIFF
--- a/frontend/src/utils/templateData.ts
+++ b/frontend/src/utils/templateData.ts
@@ -50,7 +50,7 @@ const templates: ModelTemplate[] = [
     id: 'saudi-cge',
     name: 'Saudi CGE Model',
     shortDescription: 'Energy dependent economy with expat labor considerations',
-    type: 'korea',
+    type: 'saudi',
     sectors: ['agricult', 'oilgas', 'tourism'],
     factors: ['CAP', 'LAB'],
     households: ['saudi-hh', 'expat-hh'],


### PR DESCRIPTION
## Summary
- correct Saudi template type so the right flag shows

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*
- `npm run build` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6869f820e108832a9ebefe0c23ceb71a