### PR TITLE
Fix Korean and Saudi model result formatting

### DIFF
--- a/backend/models/model_wrappers.py
+++ b/backend/models/model_wrappers.py
@@ -6,14 +6,23 @@ from . import camcge, korcge, saudicge
 
 def _extract_results(container) -> Dict[str, float]:
     """Extract key results from a solved container along with units."""
-    prices = container["px"].toDict() if "px" in container else {}
-    production = container["xd"].toDict() if "xd" in container else {}
+    prices = {}
+    if "px" in container:
+        for item in container["px"].toList():
+            if len(item) >= 2:
+                prices[str(item[0])] = float(item[1])
+
+    production = {}
+    if "xd" in container:
+        for item in container["xd"].toList():
+            if len(item) >= 2:
+                production[str(item[0])] = float(item[1])
 
     utility_var = container["omega"]
     utility = float(utility_var.toValue()) if utility_var is not None else 0.0
 
-    # According to model specifications GDP equals the objective function value
-    gdp = utility
+    # GDP is provided by variable ``y`` in the models
+    gdp = float(container["y"].toValue()) if "y" in container else 0.0
 
     financials = {}
     for var in [


### PR DESCRIPTION
## Summary
- ensure Korean and Saudi model results contain only serialisable values
- derive GDP from `y` variable instead of objective function

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6869fb9fc364832a87692b478ab6c544