### PR TITLE
Simplify Korea and Saudi output

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -373,36 +373,22 @@ def compare_scenarios():
                 baseline_results = solve_korea(baseline_tariff, baseline_itax, baseline_htax)
                 scenario_results = solve_korea(scenario_tariff, scenario_itax, scenario_htax)
 
-                def diff_dict(base: Dict[str, Dict[str, float]], other: Dict[str, Dict[str, float]]):
-                    d = {}
-                    for k in base:
-                        b = float(base[k].get('value', 0))
-                        o = float(other.get(k, {}).get('value', 0))
-                        val = o - b
-                        pct = (val / b * 100) if b != 0 else 0
-                        d[k] = {'value': val, 'percentChange': pct, 'unit': base[k].get('unit', '')}
-                    return d
+                def diff_val(b: float, o: float) -> Dict[str, float]:
+                    val = o - b
+                    pct = (val / b * 100) if b != 0 else 0
+                    return {'value': val, 'percentChange': pct}
 
-                price_diffs = diff_dict(baseline_results['prices'], scenario_results['prices'])
-                prod_diffs = diff_dict(baseline_results['production'], scenario_results['production'])
-                fin_diffs = diff_dict(baseline_results['financials'], scenario_results['financials'])
-
-                util_diff = scenario_results['utility'] - baseline_results['utility']
-                util_pct = (util_diff / baseline_results['utility'] * 100) if baseline_results['utility'] else 0
-
-                gdp_diff = scenario_results['gdp'] - baseline_results['gdp']
-                gdp_pct = (gdp_diff / baseline_results['gdp'] * 100) if baseline_results['gdp'] else 0
+                diffs = {
+                    'omega': diff_val(baseline_results['omega'], scenario_results['omega']),
+                    'y': diff_val(baseline_results['y'], scenario_results['y']),
+                    'tothhtax': diff_val(baseline_results['tothhtax'], scenario_results['tothhtax']),
+                    'yh': {hh: diff_val(baseline_results['yh'].get(hh, 0), scenario_results['yh'].get(hh, 0)) for hh in baseline_results['yh']}
+                }
 
                 return jsonify({
                     'baseline': baseline_results,
                     'scenario': scenario_results,
-                    'differences': {
-                        'prices': price_diffs,
-                        'production': prod_diffs,
-                        'financials': fin_diffs,
-                        'utility': {'value': util_diff, 'percentChange': util_pct},
-                        'gdp': {'value': gdp_diff, 'percentChange': gdp_pct},
-                    }
+                    'differences': diffs
                 })
             except Exception as kor_err:
                 error_message = f"Error comparing Korea scenarios: {kor_err}"
@@ -425,27 +411,22 @@ def compare_scenarios():
                 baseline_results = solve_saudi(baseline_tariff, baseline_itax, baseline_htax)
                 scenario_results = solve_saudi(scenario_tariff, scenario_itax, scenario_htax)
 
-                def diff_dict(base: Dict[str, Dict[str, float]], other: Dict[str, Dict[str, float]]):
-                    d = {}
-                    for k in base:
-                        b = float(base[k].get('value', 0))
-                        o = float(other.get(k, {}).get('value', 0))
-                        val = o - b
-                        pct = (val / b * 100) if b != 0 else 0
-                        d[k] = {'value': val, 'percentChange': pct, 'unit': base[k].get('unit', '')}
-                    return d
+                def diff_val(b: float, o: float) -> Dict[str, float]:
+                    val = o - b
+                    pct = (val / b * 100) if b != 0 else 0
+                    return {'value': val, 'percentChange': pct}
 
-                fin_diffs = diff_dict(baseline_results['financials'], scenario_results['financials'])
-                gdp_diff = scenario_results['gdp'] - baseline_results['gdp']
-                gdp_pct = (gdp_diff / baseline_results['gdp'] * 100) if baseline_results['gdp'] else 0
+                diffs = {
+                    'omega': diff_val(baseline_results['omega'], scenario_results['omega']),
+                    'y': diff_val(baseline_results['y'], scenario_results['y']),
+                    'tothhtax': diff_val(baseline_results['tothhtax'], scenario_results['tothhtax']),
+                    'yh': {hh: diff_val(baseline_results['yh'].get(hh, 0), scenario_results['yh'].get(hh, 0)) for hh in baseline_results['yh']}
+                }
 
                 return jsonify({
                     'baseline': baseline_results,
                     'scenario': scenario_results,
-                    'differences': {
-                        'financials': fin_diffs,
-                        'gdp': {'value': gdp_diff, 'percentChange': gdp_pct},
-                    }
+                    'differences': diffs
                 })
             except Exception as sau_err:
                 error_message = f"Error comparing Saudi scenarios: {sau_err}"

--- a/backend/models/model_wrappers.py
+++ b/backend/models/model_wrappers.py
@@ -1,5 +1,5 @@
 import importlib
-from typing import List, Optional, Dict
+from typing import List, Optional, Dict, Any
 
 from . import camcge, korcge, saudicge
 
@@ -55,6 +55,36 @@ def _extract_results(container) -> Dict[str, float]:
     }
 
 
+def _extract_summary(container) -> Dict[str, Any]:
+    """Extract a summary of key results for Korea and Saudi models."""
+    def get_val(var: str) -> float:
+        if var in container:
+            try:
+                return float(container[var].toValue())
+            except Exception:
+                return 0.0
+        return 0.0
+
+    # Household incomes are by household type
+    hh_income = {}
+    if "yh" in container:
+        try:
+            for item in container["yh"].toList():
+                if len(item) >= 2:
+                    hh_income[str(item[0])] = float(item[1])
+        except Exception:
+            hh_income = {}
+
+    summary = {
+        "omega": get_val("omega"),
+        "y": get_val("y"),
+        "tothhtax": get_val("tothhtax"),
+        "yh": hh_income,
+    }
+
+    return summary
+
+
 def solve_cameroon() -> Dict[str, float]:
     """Run the Cameroon CGE model with its default data."""
     mod = importlib.reload(camcge)
@@ -87,7 +117,7 @@ def solve_korea(
             mod.htax[hh] = float(val)
 
     mod.model1.solve(solver="CONOPT")
-    results = _extract_results(mod.m)
+    results = _extract_summary(mod.m)
     results["params"] = defaults
     return results
 
@@ -116,6 +146,6 @@ def solve_saudi(
             mod.htax[hh] = float(val)
 
     mod.model1.solve(solver="CONOPT")
-    results = _extract_results(mod.m)
+    results = _extract_summary(mod.m)
     results["params"] = defaults
     return results

--- a/frontend/src/components/ComparisonDisplay.tsx
+++ b/frontend/src/components/ComparisonDisplay.tsx
@@ -6,31 +6,70 @@ interface ComparisonDisplayProps {
 }
 
 const ComparisonDisplay = ({ comparison }: ComparisonDisplayProps) => {
-  const percentChangeData = comparison.differences.financials
-    ? Object.entries(comparison.differences.financials).map(([k, v]) => ({ name: k, change: v.percentChange }))
-    : [];
+  const hasFinancials = !!comparison.differences.financials;
 
-  const comparisonData = comparison.differences.financials
-    ? Object.entries(comparison.differences.financials).map(([k, v]) => ({
-        name: k,
+  type Row = { symbol: string; desc: string; baseline: number; scenario: number; change: number };
+  const rows: Row[] = [];
+
+  if (hasFinancials) {
+    Object.entries(comparison.differences.financials!).forEach(([k, v]) => {
+      rows.push({
+        symbol: k,
+        desc: k,
         baseline: comparison.baseline.financials?.[k]?.value || 0,
         scenario: comparison.scenario.financials?.[k]?.value || 0,
-        unit: comparison.baseline.financials?.[k]?.unit || ''
-      }))
-    : [];
+        change: v.percentChange,
+      });
+    });
+    if (comparison.differences.gdp) {
+      rows.push({
+        symbol: 'GDP',
+        desc: 'Total GDP',
+        baseline: comparison.baseline.gdp || 0,
+        scenario: comparison.scenario.gdp || 0,
+        change: comparison.differences.gdp.percentChange,
+      });
+    }
+  } else {
+    const mapping: { key: keyof ScenarioComparison['baseline']; desc: string }[] = [
+      { key: 'omega', desc: 'Total utility' },
+      { key: 'y', desc: 'Total GDP' },
+      { key: 'tothhtax', desc: 'Total household tax revenue' },
+    ];
+    mapping.forEach(({ key, desc }) => {
+      const diff: any = (comparison.differences as any)[key];
+      if (diff) {
+        rows.push({
+          symbol: String(key),
+          desc,
+          baseline: (comparison.baseline as any)[key] || 0,
+          scenario: (comparison.scenario as any)[key] || 0,
+          change: diff.percentChange,
+        });
+      }
+    });
+    if (comparison.differences.yh) {
+      Object.entries(comparison.differences.yh).forEach(([hh, diff]) => {
+        rows.push({
+          symbol: `yh(${hh})`,
+          desc: `Income for ${hh}`,
+          baseline: comparison.baseline.yh?.[hh] || 0,
+          scenario: comparison.scenario.yh?.[hh] || 0,
+          change: diff.percentChange,
+        });
+      });
+    }
+  }
+
+  const percentChangeData = rows.map(r => ({ name: r.symbol, change: r.change }));
+  const comparisonData = rows.map(r => ({ name: r.symbol, baseline: r.baseline, scenario: r.scenario }));
 
   const downloadCsv = () => {
-    const rows = [
+    const csvRows = [
       ['Indicator', 'Baseline', 'Scenario', '% Change'],
-      ...Object.entries(comparison.differences.financials || {}).map(([k, v]) => [
-        k,
-        (comparison.baseline.financials?.[k]?.value || 0).toFixed(2),
-        (comparison.scenario.financials?.[k]?.value || 0).toFixed(2),
-        v.percentChange.toFixed(2),
-      ]),
-      ['GDP', comparison.baseline.gdp.toFixed(2), comparison.scenario.gdp.toFixed(2), comparison.differences.gdp.percentChange.toFixed(2)],
+      ...rows.map(r => [r.symbol, r.baseline.toFixed(2), r.scenario.toFixed(2), r.change.toFixed(2)]),
     ];
-    const csv = rows.map(r => r.join(',')).join('\n');
+    const csv = csvRows.map(r => r.join(',')).join('\n');
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
@@ -45,7 +84,7 @@ const ComparisonDisplay = ({ comparison }: ComparisonDisplayProps) => {
   return (
     <div className="p-4 bg-white rounded-lg shadow-sm">
       <h3 className="text-lg font-medium mb-4">Scenario Comparison</h3>
-      
+
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div className="card">
           <h4 className="text-md font-medium mb-2">Key Indicators</h4>
@@ -53,39 +92,23 @@ const ComparisonDisplay = ({ comparison }: ComparisonDisplayProps) => {
             <table className="min-w-full divide-y divide-midgray/30">
               <thead>
                 <tr>
-                  <th className="px-2 py-1 text-left text-xs font-medium text-darkgray/70 uppercase tracking-wider">Indicator</th>
+                  <th className="px-2 py-1 text-left text-xs font-medium text-darkgray/70 uppercase tracking-wider">Symbol</th>
+                  <th className="px-2 py-1 text-left text-xs font-medium text-darkgray/70 uppercase tracking-wider">Description</th>
                   <th className="px-2 py-1 text-right text-xs font-medium text-darkgray/70 uppercase tracking-wider">Baseline</th>
                   <th className="px-2 py-1 text-right text-xs font-medium text-darkgray/70 uppercase tracking-wider">Scenario</th>
                   <th className="px-2 py-1 text-right text-xs font-medium text-darkgray/70 uppercase tracking-wider">% Change</th>
                 </tr>
               </thead>
               <tbody className="bg-white divide-y divide-midgray/30">
-                {Object.entries(comparison.differences.financials || {}).map(([k, v]) => (
-                  <tr key={k}>
-                    <td className="px-2 py-1 whitespace-nowrap text-sm font-medium text-darkgray">{k}</td>
-                    <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">
-                      {(comparison.baseline.financials?.[k]?.value || 0).toFixed(2)} {comparison.baseline.financials?.[k]?.unit}
-                    </td>
-                    <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">
-                      {(comparison.scenario.financials?.[k]?.value || 0).toFixed(2)} {comparison.scenario.financials?.[k]?.unit}
-                    </td>
-                    <td className={`px-2 py-1 whitespace-nowrap text-sm text-right ${
-                      v.percentChange > 0 ? 'text-success' : v.percentChange < 0 ? 'text-warning' : 'text-darkgray'
-                    }`}>
-                      {v.percentChange.toFixed(2)}%
-                    </td>
+                {rows.map(row => (
+                  <tr key={row.symbol}>
+                    <td className="px-2 py-1 whitespace-nowrap text-sm font-medium text-darkgray">{row.symbol}</td>
+                    <td className="px-2 py-1 whitespace-nowrap text-sm text-darkgray">{row.desc}</td>
+                    <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{row.baseline.toFixed(2)}</td>
+                    <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{row.scenario.toFixed(2)}</td>
+                    <td className={`px-2 py-1 whitespace-nowrap text-sm text-right ${row.change > 0 ? 'text-success' : row.change < 0 ? 'text-warning' : 'text-darkgray'}`}>{row.change.toFixed(2)}%</td>
                   </tr>
                 ))}
-                <tr>
-                  <td className="px-2 py-1 whitespace-nowrap text-sm font-medium text-darkgray">GDP</td>
-                  <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{comparison.baseline.gdp.toFixed(2)}</td>
-                  <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{comparison.scenario.gdp.toFixed(2)}</td>
-                  <td className={`px-2 py-1 whitespace-nowrap text-sm text-right ${
-                    comparison.differences.gdp.percentChange > 0 ? 'text-success' : comparison.differences.gdp.percentChange < 0 ? 'text-warning' : 'text-darkgray'
-                  }`}>
-                    {comparison.differences.gdp.percentChange.toFixed(2)}%
-                  </td>
-                </tr>
               </tbody>
             </table>
           </div>
@@ -107,29 +130,11 @@ const ComparisonDisplay = ({ comparison }: ComparisonDisplayProps) => {
           </div>
         </div>
       </div>
-      
-      {comparisonData.length > 0 && (
-        <>
-          <div className="mt-6">
-            <h4 className="text-md font-medium mb-2">Financial Comparison</h4>
-            <div className="h-64">
-              <ResponsiveContainer width="100%" height="100%">
-                <BarChart data={comparisonData} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="name" />
-                  <YAxis />
-                  <Tooltip />
-                  <Legend />
-                  <Bar dataKey="baseline" fill="#3b82f6" name="Baseline" />
-                  <Bar dataKey="scenario" fill="#10b981" name="Scenario" />
-                </BarChart>
-              </ResponsiveContainer>
-            </div>
-          </div>
-          <div className="mt-4">
-            <button onClick={downloadCsv} className="btn btn-primary">Download CSV</button>
-          </div>
-        </>
+
+      {rows.length > 0 && (
+        <div className="mt-4">
+          <button onClick={downloadCsv} className="btn btn-primary">Download CSV</button>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/screens/ModelBuilderPage.tsx
+++ b/frontend/src/screens/ModelBuilderPage.tsx
@@ -953,7 +953,52 @@ const ModelBuilderPage = () => {
       {currentStep === 6 && comparisonResults && (
         <div>
           <h2 className="text-2xl font-semibold mb-6">Scenario Comparison Results</h2>
-          
+
+          <div className="mb-6">
+            <h3 className="text-lg font-medium mb-2">Parameter Changes</h3>
+            <table className="min-w-full divide-y divide-midgray/30">
+              <thead>
+                <tr>
+                  <th className="px-2 py-1 text-left text-xs font-medium text-darkgray/70 uppercase tracking-wider">Parameter</th>
+                  <th className="px-2 py-1 text-right text-xs font-medium text-darkgray/70 uppercase tracking-wider">Baseline</th>
+                  <th className="px-2 py-1 text-right text-xs font-medium text-darkgray/70 uppercase tracking-wider">Scenario</th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-midgray/30">
+                {(() => {
+                  const rows: JSX.Element[] = [];
+                  if (modelParameters && scenarioParameters) {
+                    const keys = Object.keys(scenarioParameters) as (keyof typeof scenarioParameters)[];
+                    keys.forEach(key => {
+                      const baseVal: any = (modelParameters as any)[key];
+                      const scenVal: any = (scenarioParameters as any)[key];
+                      if (Array.isArray(baseVal) && Array.isArray(scenVal)) {
+                        baseVal.forEach((b, idx) => {
+                          if (scenVal[idx] !== b) {
+                            rows.push(
+                              <tr key={`${String(key)}-${idx}`}><td className="px-2 py-1 whitespace-nowrap text-sm text-darkgray">{`${String(key)}[${idx}]`}</td><td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{b}</td><td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{scenVal[idx]}</td></tr>
+                            );
+                          }
+                        });
+                      } else if (scenVal !== baseVal) {
+                        rows.push(
+                          <tr key={String(key)}>
+                            <td className="px-2 py-1 whitespace-nowrap text-sm text-darkgray">{String(key)}</td>
+                            <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{baseVal}</td>
+                            <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{scenVal}</td>
+                          </tr>
+                        );
+                      }
+                    });
+                  }
+                  return rows.length > 0 ? rows : (
+                    <tr><td colSpan={3} className="px-2 py-1 text-sm text-darkgray">No parameter changes</td></tr>
+                  );
+                })()}
+              </tbody>
+            </table>
+          </div>
+
           <ComparisonDisplay comparison={comparisonResults} />
           
           <div className="mt-8 flex justify-between">

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -35,19 +35,25 @@ export interface ModelParameters {
 
 // Model Results
 export interface ModelResults {
-  prices: {
+  prices?: {
     [key: string]: number;
   };
-  production: {
+  production?: {
     [key: string]: number;
   };
-  utility: number;
-  gdp: number;
+  utility?: number;
+  gdp?: number;
   financials?: {
     [key: string]: {
       value: number;
       unit?: string;
     };
+  };
+  omega?: number;
+  y?: number;
+  tothhtax?: number;
+  yh?: {
+    [key: string]: number;
   };
   params?: {
     tariff?: number[];
@@ -61,13 +67,13 @@ export interface ScenarioComparison {
   baseline: ModelResults;
   scenario: ModelResults;
   differences: {
-    prices: {
+    prices?: {
       [key: string]: {
         value: number;
         percentChange: number;
       };
     };
-    production: {
+    production?: {
       [key: string]: {
         value: number;
         percentChange: number;
@@ -80,13 +86,31 @@ export interface ScenarioComparison {
         unit?: string;
       };
     };
-    utility: {
+    utility?: {
       value: number;
       percentChange: number;
     };
-    gdp: {
+    gdp?: {
       value: number;
       percentChange: number;
+    };
+    omega?: {
+      value: number;
+      percentChange: number;
+    };
+    y?: {
+      value: number;
+      percentChange: number;
+    };
+    tothhtax?: {
+      value: number;
+      percentChange: number;
+    };
+    yh?: {
+      [key: string]: {
+        value: number;
+        percentChange: number;
+      };
     };
   };
 }


### PR DESCRIPTION
## Summary
- return only key metrics for Korea and Saudi model wrappers
- compute scenario differences for the new metrics
- update frontend types and comparison display
- show parameter differences before comparison results

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `npm test --silent` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686a0b43ac68832aa6109516b1538876