### PR TITLE
Improve scenario result display

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -381,7 +381,7 @@ def compare_scenarios():
                 diffs = {
                     'omega': diff_val(baseline_results['omega'], scenario_results['omega']),
                     'y': diff_val(baseline_results['y'], scenario_results['y']),
-                    'tothhtax': diff_val(baseline_results['tothhtax'], scenario_results['tothhtax']),
+                    'gr': diff_val(baseline_results.get('gr', 0), scenario_results.get('gr', 0)),
                     'yh': {hh: diff_val(baseline_results['yh'].get(hh, 0), scenario_results['yh'].get(hh, 0)) for hh in baseline_results['yh']}
                 }
 
@@ -419,7 +419,7 @@ def compare_scenarios():
                 diffs = {
                     'omega': diff_val(baseline_results['omega'], scenario_results['omega']),
                     'y': diff_val(baseline_results['y'], scenario_results['y']),
-                    'tothhtax': diff_val(baseline_results['tothhtax'], scenario_results['tothhtax']),
+                    'gr': diff_val(baseline_results.get('gr', 0), scenario_results.get('gr', 0)),
                     'yh': {hh: diff_val(baseline_results['yh'].get(hh, 0), scenario_results['yh'].get(hh, 0)) for hh in baseline_results['yh']}
                 }
 

--- a/backend/models/model_wrappers.py
+++ b/backend/models/model_wrappers.py
@@ -79,6 +79,7 @@ def _extract_summary(container) -> Dict[str, Any]:
         "omega": get_val("omega"),
         "y": get_val("y"),
         "tothhtax": get_val("tothhtax"),
+        "gr": get_val("gr"),
         "yh": hh_income,
     }
 

--- a/frontend/src/components/ComparisonDisplay.tsx
+++ b/frontend/src/components/ComparisonDisplay.tsx
@@ -32,9 +32,9 @@ const ComparisonDisplay = ({ comparison }: ComparisonDisplayProps) => {
     }
   } else {
     const mapping: { key: keyof ScenarioComparison['baseline']; desc: string }[] = [
-      { key: 'omega', desc: 'Total utility' },
-      { key: 'y', desc: 'Total GDP' },
-      { key: 'tothhtax', desc: 'Total household tax revenue' },
+      { key: 'omega', desc: 'Utility' },
+      { key: 'y', desc: 'GDP' },
+      { key: 'gr', desc: 'Government revenue' },
     ];
     mapping.forEach(({ key, desc }) => {
       const diff: any = (comparison.differences as any)[key];

--- a/frontend/src/components/ResultsDisplay.tsx
+++ b/frontend/src/components/ResultsDisplay.tsx
@@ -31,18 +31,18 @@ const ResultsDisplay = ({ results, title = 'Model Results', templateId }: Result
   const indicators: { label: string; value: number }[] = [];
   if (typeof results.gdp === 'number') {
     indicators.push({ label: 'GDP', value: results.gdp });
+  } else if (typeof results.y === 'number') {
+    indicators.push({ label: 'GDP', value: results.y });
   }
   if (typeof results.utility === 'number') {
     indicators.push({ label: 'Utility', value: results.utility });
+  } else if (typeof results.omega === 'number') {
+    indicators.push({ label: 'Utility', value: results.omega });
   }
-  if (typeof results.omega === 'number') {
-    indicators.push({ label: summaryOnly ? 'Utility' : 'Omega', value: results.omega });
-  }
-  if (typeof results.y === 'number') {
-    indicators.push({ label: 'GDP', value: results.y });
-  }
-  if (typeof results.tothhtax === 'number' && !summaryOnly) {
-    indicators.push({ label: 'Household Tax', value: results.tothhtax });
+  if (typeof results.gr === 'number') {
+    indicators.push({ label: 'Government Revenue', value: results.gr });
+  } else if (results.financials?.gr?.value !== undefined) {
+    indicators.push({ label: 'Government Revenue', value: results.financials.gr.value });
   }
   if (results.yh) {
     Object.entries(results.yh).forEach(([hh, val]) => {

--- a/frontend/src/screens/ModelBuilderPage.tsx
+++ b/frontend/src/screens/ModelBuilderPage.tsx
@@ -975,8 +975,20 @@ const ModelBuilderPage = () => {
                       if (Array.isArray(baseVal) && Array.isArray(scenVal)) {
                         baseVal.forEach((b, idx) => {
                           if (scenVal[idx] !== b) {
+                            let label = `${String(key)}[${idx}]`;
+                            if (selectedTemplate && (selectedTemplate.id === 'korea-cge' || selectedTemplate.id === 'saudi-cge')) {
+                              if (key === 'incomeTax' && samData.households[idx]) {
+                                label = `${String(key)} (${samData.households[idx]})`;
+                              } else if ((key === 'tariff' || key === 'indirectTax') && samData.goods[idx]) {
+                                label = `${String(key)} (${samData.goods[idx]})`;
+                              }
+                            }
                             rows.push(
-                              <tr key={`${String(key)}-${idx}`}><td className="px-2 py-1 whitespace-nowrap text-sm text-darkgray">{`${String(key)}[${idx}]`}</td><td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{b}</td><td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{scenVal[idx]}</td></tr>
+                              <tr key={`${String(key)}-${idx}`}>
+                                <td className="px-2 py-1 whitespace-nowrap text-sm text-darkgray">{label}</td>
+                                <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{b}</td>
+                                <td className="px-2 py-1 whitespace-nowrap text-sm text-right text-darkgray">{scenVal[idx]}</td>
+                              </tr>
                             );
                           }
                         });

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -52,6 +52,7 @@ export interface ModelResults {
   omega?: number;
   y?: number;
   tothhtax?: number;
+  gr?: number;
   yh?: {
     [key: string]: number;
   };
@@ -99,6 +100,10 @@ export interface ScenarioComparison {
       percentChange: number;
     };
     y?: {
+      value: number;
+      percentChange: number;
+    };
+    gr?: {
       value: number;
       percentChange: number;
     };


### PR DESCRIPTION
## Summary
- surface government revenue in Korea/Saudi summary results
- compute scenario differences for government revenue
- show sector/household names for parameter changes
- rename omega indicator label to Utility and include government revenue
- update types for new `gr` field

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*
- `pytest` *(fails: ModuleNotFoundError: requests)*

------
https://chatgpt.com/codex/tasks/task_e_686a25e91d60832a9a94dbd2e96b0b3b