### PR TITLE
Add option to auto-populate agent names from uploaded SAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Future versions will add:
 - Model builder with step-by-step workflow
 - Template selection interface
 - SAM editor with CSV/Excel upload capability
+- Option to auto-populate sector, factor and household names from uploaded SAM headers
 - Parameter input forms
 - Results visualization with charts
 - Scenario comparison dashboard

--- a/frontend/src/components/FileUploader.tsx
+++ b/frontend/src/components/FileUploader.tsx
@@ -7,9 +7,23 @@ interface FileUploaderProps {
   goods: string[];
   factors: string[];
   households: string[];
+  /**
+   * When true, use the uploaded SAM's header names to populate sector,
+   * factor and household names instead of validating against the
+   * provided lists.
+   */
+  autoPopulateNames?: boolean;
+  onNamesLoaded?: (goods: string[], factors: string[], households: string[]) => void;
 }
 
-const FileUploader = ({ onSamLoaded, goods, factors, households }: FileUploaderProps) => {
+const FileUploader = ({
+  onSamLoaded,
+  goods,
+  factors,
+  households,
+  autoPopulateNames = false,
+  onNamesLoaded,
+}: FileUploaderProps) => {
   const [isDragging, setIsDragging] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [warning, setWarning] = useState<string | null>(null);
@@ -59,8 +73,7 @@ const FileUploader = ({ onSamLoaded, goods, factors, households }: FileUploaderP
       }
 
       if (parsed) {
-        const expectedEntries = [...goods, ...factors, ...households];
-        const expectedSize = expectedEntries.length;
+        const expectedSize = goods.length + factors.length + households.length;
 
         const trimmedHeader = parsed.columnNames.map(n => n.trim());
         const trimmedRows = parsed.rowNames.map(n => n.trim());
@@ -75,51 +88,78 @@ const FileUploader = ({ onSamLoaded, goods, factors, households }: FileUploaderP
           return;
         }
 
-        const trimmedExpected = expectedEntries.map(n => n.trim());
+        if (autoPopulateNames && onNamesLoaded) {
+          const rowMismatch = trimmedRows.some((n, i) => n !== trimmedHeader[i]);
+          if (rowMismatch) {
+            setWarning('Row and column names differ; column names used.');
+          } else {
+            setWarning(null);
+          }
 
-        const headerSet = new Set(trimmedHeader);
-        const rowSet = new Set(trimmedRows);
+          const goodsNames = trimmedHeader.slice(0, goods.length);
+          const factorNames = trimmedHeader.slice(goods.length, goods.length + factors.length);
+          const householdNames = trimmedHeader.slice(goods.length + factors.length);
 
-        const headerMatches =
-          headerSet.size === trimmedExpected.length &&
-          trimmedExpected.every(n => headerSet.has(n));
-        const rowMatches =
-          rowSet.size === trimmedExpected.length &&
-          trimmedExpected.every(n => rowSet.has(n));
+          onNamesLoaded(goodsNames, factorNames, householdNames);
 
-        if (!headerMatches || !rowMatches) {
-          setError(
-            `Names must match configured entries: ${trimmedExpected.join(', ')}`
-          );
-          return;
+          const sam: SAM = {
+            entries: trimmedHeader,
+            goods: goodsNames,
+            factors: factorNames,
+            households: householdNames,
+            data: parsed.data,
+          };
+
+          onSamLoaded(sam);
+        } else {
+          const expectedEntries = [...goods, ...factors, ...households];
+
+          const trimmedExpected = expectedEntries.map(n => n.trim());
+
+          const headerSet = new Set(trimmedHeader);
+          const rowSet = new Set(trimmedRows);
+
+          const headerMatches =
+            headerSet.size === trimmedExpected.length &&
+            trimmedExpected.every(n => headerSet.has(n));
+          const rowMatches =
+            rowSet.size === trimmedExpected.length &&
+            trimmedExpected.every(n => rowSet.has(n));
+
+          if (!headerMatches || !rowMatches) {
+            setError(
+              `Names must match configured entries: ${trimmedExpected.join(', ')}`
+            );
+            return;
+          }
+
+          // Reorder rows and columns to match expected entry order
+          const colIndexMap: Record<string, number> = {};
+          trimmedHeader.forEach((name, idx) => {
+            colIndexMap[name] = idx;
+          });
+
+          const rowIndexMap: Record<string, number> = {};
+          trimmedRows.forEach((name, idx) => {
+            rowIndexMap[name] = idx;
+          });
+
+          const reorderedData = expectedEntries.map(rowName => {
+            const originalRow = parsed!.data[rowIndexMap[rowName]];
+            return expectedEntries.map(colName => originalRow[colIndexMap[colName]]);
+          });
+
+          const sam: SAM = {
+            entries: expectedEntries,
+            goods,
+            factors,
+            households,
+            data: reorderedData,
+          };
+
+          setWarning(null);
+          onSamLoaded(sam);
         }
-
-        // Reorder rows and columns to match expected entry order
-        const colIndexMap: Record<string, number> = {};
-        trimmedHeader.forEach((name, idx) => {
-          colIndexMap[name] = idx;
-        });
-
-        const rowIndexMap: Record<string, number> = {};
-        trimmedRows.forEach((name, idx) => {
-          rowIndexMap[name] = idx;
-        });
-
-        const reorderedData = expectedEntries.map(rowName => {
-          const originalRow = parsed!.data[rowIndexMap[rowName]];
-          return expectedEntries.map(colName => originalRow[colIndexMap[colName]]);
-        });
-
-        const sam: SAM = {
-          entries: expectedEntries,
-          goods,
-          factors,
-          households,
-          data: reorderedData,
-        };
-
-        setWarning(null);
-        onSamLoaded(sam);
       } else {
         setError('Failed to parse the SAM data. Please check the file format.');
       }

--- a/frontend/src/screens/ModelBuilderPage.tsx
+++ b/frontend/src/screens/ModelBuilderPage.tsx
@@ -36,6 +36,7 @@ const ModelBuilderPage = () => {
   const [factorNames, setFactorNames] = useState<string[]>(['FACTOR1', 'FACTOR2']);
   const [householdNames, setHouseholdNames] = useState<string[]>(['HH1']);
   const [useCustomNames, setUseCustomNames] = useState<boolean>(false);
+  const [populateNamesFromFile, setPopulateNamesFromFile] = useState<boolean>(false);
   
   // SAM data
   // Use functional initializer so the default SAM is generated only once
@@ -303,12 +304,18 @@ const ModelBuilderPage = () => {
   const handleSamUpload = (sam: SAM) => {
     setSamData(sam);
     setIsCustomSam(true);
-    
+
     // Update parameters to match the new SAM dimensions
     setModelParameters({
       alpha: sam.goods.map((_, index) => 1 / sam.goods.length),
       b: sam.goods.map(() => 1.0)
     });
+  };
+
+  const handleNamesLoaded = (goodsFromFile: string[], factorsFromFile: string[], householdsFromFile: string[]) => {
+    setSectorNames(goodsFromFile);
+    setFactorNames(factorsFromFile);
+    setHouseholdNames(householdsFromFile);
   };
 
   // Download the current SAM as a CSV file
@@ -483,6 +490,7 @@ const ModelBuilderPage = () => {
     setFactorNames(['FACTOR1', 'FACTOR2']);
     setHouseholdNames(['HH1']);
     setUseCustomNames(false);
+    setPopulateNamesFromFile(false);
     setSamConfigured(false);
   };
   
@@ -703,6 +711,20 @@ const ModelBuilderPage = () => {
               </label>
             </div>
 
+            {useCustomNames && (
+              <div className="mb-6">
+                <label className="flex items-center">
+                  <input
+                    type="checkbox"
+                    checked={populateNamesFromFile}
+                    onChange={(e) => setPopulateNamesFromFile(e.target.checked)}
+                    className="mr-2"
+                  />
+                  <span className="text-sm font-medium">Load names from uploaded SAM</span>
+                </label>
+              </div>
+            )}
+
             {/* Custom naming section */}
             {useCustomNames && (
               <div className="mb-6 space-y-4">
@@ -789,6 +811,8 @@ const ModelBuilderPage = () => {
                     goods={sectorNames}
                     factors={factorNames}
                     households={householdNames}
+                    autoPopulateNames={populateNamesFromFile}
+                    onNamesLoaded={handleNamesLoaded}
                   />
                 </div>
 


### PR DESCRIPTION
## Summary
- allow FileUploader to populate names from uploaded SAM headers
- expose an `onNamesLoaded` callback
- add option in ModelBuilderPage to load names from uploaded file
- reset this option on reset and document the feature in README

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_687b9c178ff4832a94facf0bfbbe9ebc