### PR TITLE
Implement run history feature

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -11,7 +11,7 @@ from email.message import EmailMessage
 from werkzeug.security import generate_password_hash, check_password_hash
 from models.splcge import add_input_solve
 from models.dynamic_splcge import dynamic_solve, extract_results
-from typing import Dict
+from typing import Dict, Optional
 from sam_utils.generator import generate_random_sam as gen_sam
 from utils.validators import (
     RequestValidationError,
@@ -59,10 +59,62 @@ def init_db():
             avatar = f"{row['username'][0].upper()}|{color}"
             conn.execute("UPDATE users SET avatar=? WHERE id=?", (avatar, row['id']))
 
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS runs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                template_id TEXT NOT NULL,
+                params TEXT,
+                sam TEXT,
+                results TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY(user_id) REFERENCES users(id)
+            )
+            """
+        )
+
         conn.commit()
 
 
 init_db()
+
+
+def get_user_id(username: str) -> int | None:
+    with get_db_connection() as conn:
+        cur = conn.execute('SELECT id FROM users WHERE username=?', (username,))
+        row = cur.fetchone()
+        return row['id'] if row else None
+
+
+def insert_run(user_id: int, template_id: str, params: Dict, sam: Optional[Dict], results: Dict) -> int:
+    with get_db_connection() as conn:
+        cur = conn.execute(
+            'INSERT INTO runs (user_id, template_id, params, sam, results) VALUES (?, ?, ?, ?, ?)',
+            (user_id, template_id, json.dumps(params), json.dumps(sam) if sam else None, json.dumps(results)),
+        )
+        conn.commit()
+        return cur.lastrowid
+
+
+def fetch_runs_for_user(user_id: int) -> list[Dict]:
+    with get_db_connection() as conn:
+        cur = conn.execute(
+            'SELECT id, template_id, params, sam, results, created_at FROM runs WHERE user_id=? ORDER BY created_at DESC',
+            (user_id,),
+        )
+        rows = cur.fetchall()
+        return [dict(row) for row in rows]
+
+
+def fetch_run(run_id: int) -> Optional[Dict]:
+    with get_db_connection() as conn:
+        cur = conn.execute(
+            'SELECT id, user_id, template_id, params, sam, results, created_at FROM runs WHERE id=?',
+            (run_id,),
+        )
+        row = cur.fetchone()
+        return dict(row) if row else None
 
 
 def send_contact_email(name: str, email: str, message: str):
@@ -333,6 +385,53 @@ def login():
         return jsonify({'error': 'Invalid credentials'}), 401
     except Exception as e:
         return jsonify({'error': str(e)}), 500
+
+
+@app.route('/runs', methods=['POST'])
+def record_run():
+    try:
+        data = parse_json_request(request)
+    except RequestValidationError as exc:
+        return jsonify({'error': exc.message}), exc.status_code
+
+    user_id = data.get('userId')
+    username = data.get('username')
+    if not user_id and username:
+        user_id = get_user_id(username)
+
+    if not user_id:
+        return jsonify({'error': 'Valid userId or username required'}), 400
+
+    template_id = data.get('templateId')
+    params = data.get('params', {})
+    sam = data.get('sam')
+    results = data.get('results', {})
+
+    run_id = insert_run(user_id, template_id, params, sam, results)
+    return jsonify({'id': run_id, 'message': 'Run saved'})
+
+
+@app.route('/runs', methods=['GET'])
+def list_runs():
+    username = request.args.get('username')
+    user_id = request.args.get('userId', type=int)
+
+    if not user_id and username:
+        user_id = get_user_id(username)
+
+    if not user_id:
+        return jsonify({'error': 'Valid userId or username required'}), 400
+
+    runs = fetch_runs_for_user(user_id)
+    return jsonify(runs)
+
+
+@app.route('/runs/<int:run_id>', methods=['GET'])
+def get_run(run_id: int):
+    run = fetch_run(run_id)
+    if run:
+        return jsonify(run)
+    return jsonify({'error': 'Run not found'}), 404
 
 @app.route('/compare-scenarios', methods=['POST'])
 def compare_scenarios():

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import SignupPage from './screens/SignupPage';
 import AboutPage from './screens/AboutPage';
 import BlogPage from './screens/BlogPage';
 import ContactPage from './screens/ContactPage';
+import RunHistoryPage from './screens/RunHistoryPage';
 import './styles/index.css';
 
 const App = () => {
@@ -22,6 +23,7 @@ const App = () => {
             <Route path="/about" element={<AboutPage />} />
             <Route path="/contact" element={<ContactPage />} />
             <Route path="/model-builder" element={<ModelBuilderPage />} />
+            <Route path="/runs" element={<RunHistoryPage />} />
             <Route path="/login" element={<LoginPage />} />
             <Route path="/signup" element={<SignupPage />} />
           </Routes>

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -79,6 +79,18 @@ const Navbar = () => {
                   Model Builder
                 </Link>
               )}
+              {username && (
+                <Link
+                  to="/runs"
+                  className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
+                    location.pathname === '/runs'
+                      ? 'border-primary text-darkgray'
+                      : 'border-transparent text-midgray hover:text-darkgray'
+                  }`}
+                >
+                  Run History
+                </Link>
+              )}
             </div>
           </div>
           <div className="flex items-center">

--- a/frontend/src/screens/ModelBuilderPage.tsx
+++ b/frontend/src/screens/ModelBuilderPage.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useContext } from 'react';
+import { useLocation } from 'react-router-dom';
 import TemplateCard from '../components/TemplateCard';
 import SAMTable from '../components/SAMTable';
 import ParameterInputs from '../components/ParameterInputs';
@@ -16,9 +17,13 @@ import {
   exportSamToCsv,
   exportSamToExcel,
 } from '../utils/samUtils';
-import { solveModel, compareScenarios } from '../utils/api';
+import { solveModel, compareScenarios, saveRun } from '../utils/api';
+import { AuthContext } from '../contexts/AuthContext';
 
 const ModelBuilderPage = () => {
+  const location = useLocation();
+  const { username } = useContext(AuthContext);
+
   // Step tracking
   const [currentStep, setCurrentStep] = useState<number>(1);
   
@@ -63,6 +68,29 @@ const ModelBuilderPage = () => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const [detailedError, setDetailedError] = useState<string | null>(null);
+
+  // Load run data when navigating from history
+  useEffect(() => {
+    const state: any = location.state;
+    if (state && state.run) {
+      const run = state.run;
+      const tpl = templates.find(t => t.id === run.template_id) || null;
+      if (tpl) setSelectedTemplate(tpl);
+      if (run.sam) {
+        setSamData(run.sam);
+        setIsCustomSam(true);
+        setSamConfigured(true);
+      }
+      if (run.params) {
+        setModelParameters(run.params);
+        setScenarioParameters({ ...run.params });
+      }
+      if (run.results) {
+        setModelResults(run.results);
+        setCurrentStep(5);
+      }
+    }
+  }, [location.state]);
   
   // Reset when template changes
   useEffect(() => {
@@ -375,6 +403,7 @@ const ModelBuilderPage = () => {
         setModelParameters({ ...modelParameters, ...results.params });
       }
       setModelResults(results);
+      await saveRun(username, templateId, modelParameters, isCustomSam ? samData : undefined, results);
       setCurrentStep(4);
     } catch (err) {
       console.error('Error solving model:', err);
@@ -431,6 +460,13 @@ const ModelBuilderPage = () => {
       );
       
       setComparisonResults(results);
+      await saveRun(
+        username,
+        templateId,
+        { baseline: modelParameters, scenario: scenarioParameters },
+        isCustomSam ? samData : undefined,
+        results
+      );
       setCurrentStep(6);
     } catch (err) {
       console.error('Error comparing scenarios:', err);

--- a/frontend/src/screens/RunHistoryPage.tsx
+++ b/frontend/src/screens/RunHistoryPage.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState, useContext } from 'react';
+import { listRuns } from '../utils/api';
+import { AuthContext } from '../contexts/AuthContext';
+import { useNavigate } from 'react-router-dom';
+
+interface RunRecord {
+  id: number;
+  template_id: string;
+  params: any;
+  sam: any;
+  results: any;
+  created_at: string;
+}
+
+const RunHistoryPage = () => {
+  const { username } = useContext(AuthContext);
+  const [runs, setRuns] = useState<RunRecord[]>([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchRuns = async () => {
+      const data = await listRuns(username);
+      if (data) setRuns(data);
+    };
+    fetchRuns();
+  }, [username]);
+
+  const downloadResults = (run: RunRecord) => {
+    const blob = new Blob([JSON.stringify(run.results, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `run-${run.id}.json`;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const startScenario = (run: RunRecord) => {
+    navigate('/model-builder', { state: { run } });
+  };
+
+  if (!username) {
+    return <div className="p-4">Please log in to view runs.</div>;
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto my-8">
+      <h2 className="text-2xl font-semibold mb-6">Run History</h2>
+      {runs.length === 0 ? (
+        <p>No runs recorded.</p>
+      ) : (
+        <div className="space-y-4">
+          {runs.map((run) => (
+            <div key={run.id} className="p-4 bg-white rounded shadow-sm flex justify-between items-center">
+              <div>
+                <p className="font-medium">{run.template_id}</p>
+                <p className="text-sm text-darkgray/70">{new Date(run.created_at).toLocaleString()}</p>
+              </div>
+              <div className="space-x-2">
+                <button className="btn" onClick={() => downloadResults(run)}>Download</button>
+                <button className="btn btn-primary" onClick={() => startScenario(run)}>Start Scenario</button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RunHistoryPage;

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -119,6 +119,34 @@ export const sendContactMessage = async (
   return response.data;
 };
 
+export const saveRun = async (
+  username: string | undefined,
+  templateId: string,
+  params: any,
+  sam: SAM | undefined,
+  results: any
+) => {
+  if (!username) return;
+  await api.post('/runs', {
+    username,
+    templateId,
+    params,
+    sam,
+    results,
+  });
+};
+
+export const listRuns = async (username: string | undefined) => {
+  if (!username) return [] as any[];
+  const response = await api.get('/runs', { params: { username } });
+  return response.data as any[];
+};
+
+export const getRun = async (id: number) => {
+  const response = await api.get(`/runs/${id}`);
+  return response.data as any;
+};
+
 // avatar format "<LETTER>|<COLOR>"
 export const registerUser = async (
   username: string,


### PR DESCRIPTION
## Summary
- extend backend database with new `runs` table and helper functions
- provide `/runs` API routes
- expose `saveRun`, `listRuns`, and `getRun` utilities
- add run history page and navbar link
- save runs when solving or comparing models

## Testing
- `python -m py_compile backend/app.py`
- `npm run lint` *(fails: ESLint couldn't find the plugin)*

------
https://chatgpt.com/codex/tasks/task_e_687bc0be2988832a8d99d668fdddc6e0