### PR TITLE
Fix graphs on scenario comparison screen

### DIFF
--- a/frontend/src/components/ComparisonDisplay.tsx
+++ b/frontend/src/components/ComparisonDisplay.tsx
@@ -31,16 +31,18 @@ const ComparisonDisplay = ({ comparison }: ComparisonDisplayProps) => {
       });
     }
   } else {
-    const mapping: { key: keyof ScenarioComparison['baseline']; desc: string }[] = [
+    const mapping: { key: string; desc: string }[] = [
       { key: 'omega', desc: 'Utility' },
+      { key: 'utility', desc: 'Utility' },
       { key: 'y', desc: 'GDP' },
+      { key: 'gdp', desc: 'GDP' },
       { key: 'gr', desc: 'Government revenue' },
     ];
     mapping.forEach(({ key, desc }) => {
       const diff: any = (comparison.differences as any)[key];
-      if (diff) {
+      if (diff !== undefined) {
         rows.push({
-          symbol: String(key),
+          symbol: key,
           desc,
           baseline: (comparison.baseline as any)[key] || 0,
           scenario: (comparison.scenario as any)[key] || 0,


### PR DESCRIPTION
## Summary
- handle `utility`/`gdp` keys in `ComparisonDisplay`

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*
- `npm run build` *(fails: missing node modules)*

------
https://chatgpt.com/codex/tasks/task_e_687bd4e7b2e0832ab348b94d8f17b059