### PR TITLE
Fix run history start scenario

### DIFF
--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -139,12 +139,24 @@ export const saveRun = async (
 export const listRuns = async (username: string | undefined) => {
   if (!username) return [] as any[];
   const response = await api.get('/runs', { params: { username } });
-  return response.data as any[];
+  const runs = response.data as any[];
+  return runs.map((run) => ({
+    ...run,
+    params: run.params ? JSON.parse(run.params) : null,
+    sam: run.sam ? JSON.parse(run.sam) : null,
+    results: run.results ? JSON.parse(run.results) : null,
+  }));
 };
 
 export const getRun = async (id: number) => {
   const response = await api.get(`/runs/${id}`);
-  return response.data as any;
+  const run = response.data as any;
+  return {
+    ...run,
+    params: run.params ? JSON.parse(run.params) : null,
+    sam: run.sam ? JSON.parse(run.sam) : null,
+    results: run.results ? JSON.parse(run.results) : null,
+  };
 };
 
 // avatar format "<LETTER>|<COLOR>"


### PR DESCRIPTION
## Summary
- parse JSON strings returned from the backend when listing or fetching runs

## Testing
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_687bd6a67b44832a85ed55e35b925589