### PR TITLE
Add run history deletion options

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -117,6 +117,18 @@ def fetch_run(run_id: int) -> Optional[Dict]:
         return dict(row) if row else None
 
 
+def delete_run(run_id: int) -> None:
+    with get_db_connection() as conn:
+        conn.execute('DELETE FROM runs WHERE id=?', (run_id,))
+        conn.commit()
+
+
+def delete_runs_for_user(user_id: int) -> None:
+    with get_db_connection() as conn:
+        conn.execute('DELETE FROM runs WHERE user_id=?', (user_id,))
+        conn.commit()
+
+
 def send_contact_email(name: str, email: str, message: str):
     smtp_server = os.environ.get('SMTP_SERVER', 'localhost')
     smtp_port = int(os.environ.get('SMTP_PORT', 25))
@@ -432,6 +444,40 @@ def get_run(run_id: int):
     if run:
         return jsonify(run)
     return jsonify({'error': 'Run not found'}), 404
+
+
+@app.route('/runs/<int:run_id>', methods=['DELETE'])
+def remove_run(run_id: int):
+    username = request.args.get('username')
+    user_id = request.args.get('userId', type=int)
+
+    if not user_id and username:
+        user_id = get_user_id(username)
+
+    run = fetch_run(run_id)
+    if not run:
+        return jsonify({'error': 'Run not found'}), 404
+
+    if user_id and run['user_id'] != user_id:
+        return jsonify({'error': 'Run not found for this user'}), 404
+
+    delete_run(run_id)
+    return jsonify({'message': 'Run deleted'})
+
+
+@app.route('/runs', methods=['DELETE'])
+def clear_runs():
+    username = request.args.get('username')
+    user_id = request.args.get('userId', type=int)
+
+    if not user_id and username:
+        user_id = get_user_id(username)
+
+    if not user_id:
+        return jsonify({'error': 'Valid userId or username required'}), 400
+
+    delete_runs_for_user(user_id)
+    return jsonify({'message': 'Run history cleared'})
 
 @app.route('/compare-scenarios', methods=['POST'])
 def compare_scenarios():

--- a/frontend/src/screens/RunHistoryPage.tsx
+++ b/frontend/src/screens/RunHistoryPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useContext } from 'react';
-import { listRuns } from '../utils/api';
+import { listRuns, deleteRun, clearRuns } from '../utils/api';
 import { AuthContext } from '../contexts/AuthContext';
 import { useNavigate } from 'react-router-dom';
 
@@ -39,13 +39,31 @@ const RunHistoryPage = () => {
     navigate('/model-builder', { state: { run } });
   };
 
+  const removeRun = async (id: number) => {
+    await deleteRun(id, username);
+    setRuns(runs.filter((r) => r.id !== id));
+  };
+
+  const clearHistory = async () => {
+    if (runs.length === 0) return;
+    await clearRuns(username);
+    setRuns([]);
+  };
+
   if (!username) {
     return <div className="p-4">Please log in to view runs.</div>;
   }
 
   return (
     <div className="max-w-3xl mx-auto my-8">
-      <h2 className="text-2xl font-semibold mb-6">Run History</h2>
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-2xl font-semibold">Run History</h2>
+        {runs.length > 0 && (
+          <button className="btn btn-secondary" onClick={clearHistory}>
+            Clear History
+          </button>
+        )}
+      </div>
       {runs.length === 0 ? (
         <p>No runs recorded.</p>
       ) : (
@@ -58,6 +76,7 @@ const RunHistoryPage = () => {
               </div>
               <div className="space-x-2">
                 <button className="btn" onClick={() => downloadResults(run)}>Download</button>
+                <button className="btn" onClick={() => removeRun(run.id)}>Delete</button>
                 <button className="btn btn-primary" onClick={() => startScenario(run)}>Start Scenario</button>
               </div>
             </div>

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -148,6 +148,16 @@ export const listRuns = async (username: string | undefined) => {
   }));
 };
 
+export const deleteRun = async (id: number, username: string | undefined) => {
+  if (!username) return;
+  await api.delete(`/runs/${id}`, { params: { username } });
+};
+
+export const clearRuns = async (username: string | undefined) => {
+  if (!username) return;
+  await api.delete('/runs', { params: { username } });
+};
+
 export const getRun = async (id: number) => {
   const response = await api.get(`/runs/${id}`);
   const run = response.data as any;


### PR DESCRIPTION
## Summary
- allow removing individual runs and clearing run history
- expose new `DELETE /runs` and `DELETE /runs/<id>` backend routes
- add API helpers for deletion actions
- update Run History page with Delete buttons and a Clear History button

## Testing
- `python -m py_compile backend/app.py`
- *(npm dependencies unavailable to run frontend linters)*

------
https://chatgpt.com/codex/tasks/task_e_687bd9de0494832a96e55dda24510e4b