### PR TITLE
feat: add MN1 model wizard UI

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -334,6 +334,16 @@ def solve_model():
                 print(stack_trace)
                 return jsonify({'error': error_message, 'trace': stack_trace}), 500
 
+        elif template_id == 'mn1-cge':
+            # Placeholder implementation for MN1 model integration
+            return jsonify({
+                'message': 'MN1 model execution placeholder',
+                'prices': params.get('prices'),
+                'wage': params.get('wage'),
+                'closureRules': params.get('closureRules', []),
+                'shocks': params.get('shocks', []),
+            })
+
         else:
             # For other templates (not implemented in MVP)
             return jsonify({

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import AboutPage from './screens/AboutPage';
 import BlogPage from './screens/BlogPage';
 import ContactPage from './screens/ContactPage';
 import RunHistoryPage from './screens/RunHistoryPage';
+import ProjectWizardPage from './screens/ProjectWizardPage';
 import './styles/index.css';
 
 const App = () => {
@@ -23,6 +24,7 @@ const App = () => {
             <Route path="/about" element={<AboutPage />} />
             <Route path="/contact" element={<ContactPage />} />
             <Route path="/model-builder" element={<ModelBuilderPage />} />
+            <Route path="/project-wizard" element={<ProjectWizardPage />} />
             <Route path="/runs" element={<RunHistoryPage />} />
             <Route path="/login" element={<LoginPage />} />
             <Route path="/signup" element={<SignupPage />} />

--- a/frontend/src/components/ClosureRuleBuilder.tsx
+++ b/frontend/src/components/ClosureRuleBuilder.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import { ClosureRule } from '../utils/types';
+
+interface Props {
+  rules: ClosureRule[];
+  onAdd: (rule: ClosureRule) => void;
+  onRemove: (index: number) => void;
+}
+
+const ClosureRuleBuilder = ({ rules, onAdd, onRemove }: Props) => {
+  const [variable, setVariable] = useState('');
+  const [indices, setIndices] = useState('');
+
+  const handleAdd = () => {
+    if (!variable) return;
+    const idx = indices
+      ? indices.split(',').map((s) => s.trim()).filter(Boolean)
+      : [];
+    onAdd({ variable, indices: idx });
+    setVariable('');
+    setIndices('');
+  };
+
+  return (
+    <div>
+      <div className="flex gap-2 items-center">
+        <select
+          value={variable}
+          onChange={(e) => setVariable(e.target.value)}
+          className="border p-1"
+        >
+          <option value="">Select variable</option>
+          <option value="P">P (price)</option>
+          <option value="W">W (wage)</option>
+          <option value="LS">LS (labor supply)</option>
+        </select>
+        <input
+          type="text"
+          value={indices}
+          onChange={(e) => setIndices(e.target.value)}
+          placeholder="Indices (comma separated)"
+          className="border p-1 flex-1"
+        />
+        <button
+          type="button"
+          onClick={handleAdd}
+          className="bg-blue-500 text-white px-2 py-1"
+        >
+          Add
+        </button>
+      </div>
+      <ul className="mt-2">
+        {rules.map((r, i) => (
+          <li key={i} className="flex justify-between items-center border-b py-1">
+            <span>
+              {r.variable}[{r.indices.join(',') || 'all'}]
+            </span>
+            <button
+              onClick={() => onRemove(i)}
+              className="text-red-500"
+            >
+              Remove
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ClosureRuleBuilder;

--- a/frontend/src/components/ShockBuilder.tsx
+++ b/frontend/src/components/ShockBuilder.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { Shock } from '../utils/types';
+
+interface Props {
+  shocks: Shock[];
+  onAdd: (shock: Shock) => void;
+  onRemove: (index: number) => void;
+}
+
+const ShockBuilder = ({ shocks, onAdd, onRemove }: Props) => {
+  const [target, setTarget] = useState('');
+  const [indices, setIndices] = useState('');
+  const [multiplier, setMultiplier] = useState(1);
+
+  const handleAdd = () => {
+    if (!target) return;
+    const idx = indices
+      ? indices.split(',').map((s) => s.trim()).filter(Boolean)
+      : [];
+    onAdd({ target, indices: idx, multiplier: Number(multiplier) });
+    setTarget('');
+    setIndices('');
+    setMultiplier(1);
+  };
+
+  return (
+    <div>
+      <div className="flex gap-2 items-center">
+        <select
+          value={target}
+          onChange={(e) => setTarget(e.target.value)}
+          className="border p-1"
+        >
+          <option value="">Select target</option>
+          <option value="A">A (productivity)</option>
+          <option value="BETA">BETA (consumption)</option>
+          <option value="LS">LS (labor supply)</option>
+        </select>
+        <input
+          type="text"
+          value={indices}
+          onChange={(e) => setIndices(e.target.value)}
+          placeholder="Indices (comma separated)"
+          className="border p-1 flex-1"
+        />
+        <input
+          type="number"
+          step="0.01"
+          value={multiplier}
+          onChange={(e) => setMultiplier(Number(e.target.value))}
+          className="border p-1 w-24"
+        />
+        <button
+          type="button"
+          onClick={handleAdd}
+          className="bg-blue-500 text-white px-2 py-1"
+        >
+          Add
+        </button>
+      </div>
+      <ul className="mt-2">
+        {shocks.map((s, i) => (
+          <li key={i} className="flex justify-between items-center border-b py-1">
+            <span>
+              {s.target}[{s.indices.join(',') || 'all'}] × {s.multiplier}
+            </span>
+            <button
+              onClick={() => onRemove(i)}
+              className="text-red-500"
+            >
+              Remove
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ShockBuilder;

--- a/frontend/src/screens/ProjectWizardPage.tsx
+++ b/frontend/src/screens/ProjectWizardPage.tsx
@@ -1,0 +1,249 @@
+import { useState } from 'react';
+import FileUploader from '../components/FileUploader';
+import SAMTable from '../components/SAMTable';
+import ClosureRuleBuilder from '../components/ClosureRuleBuilder';
+import ShockBuilder from '../components/ShockBuilder';
+import ResultsDisplay from '../components/ResultsDisplay';
+import {
+  SAM,
+  ModelParameters,
+  ClosureRule,
+  Shock,
+  ModelResults,
+} from '../utils/types';
+import { solveModel } from '../utils/api';
+
+const ProjectWizardPage = () => {
+  const [step, setStep] = useState(1);
+  const [sam, setSam] = useState<SAM | null>(null);
+  const [prices, setPrices] = useState<string[]>([]);
+  const [wage, setWage] = useState('');
+  const [calibration, setCalibration] = useState<'auto' | 'manual'>('auto');
+  const [beta, setBeta] = useState('');
+  const [alpha, setAlpha] = useState('');
+  const [A, setA] = useState('');
+  const [rules, setRules] = useState<ClosureRule[]>([]);
+  const [shocks, setShocks] = useState<Shock[]>([]);
+  const [results, setResults] = useState<ModelResults | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSamLoaded = (data: SAM) => {
+    setSam(data);
+    setPrices(Array(data.goods.length).fill(''));
+  };
+
+  const handleAddRule = (rule: ClosureRule) => setRules([...rules, rule]);
+  const handleRemoveRule = (i: number) =>
+    setRules(rules.filter((_, idx) => idx !== i));
+
+  const handleAddShock = (shock: Shock) => setShocks([...shocks, shock]);
+  const handleRemoveShock = (i: number) =>
+    setShocks(shocks.filter((_, idx) => idx !== i));
+
+  const runModel = async () => {
+    setLoading(true);
+    try {
+      const params: ModelParameters = {
+        alpha: [],
+        b: [],
+        prices: prices.map((p) => Number(p)),
+        wage: wage ? Number(wage) : undefined,
+        beta: beta ? beta.split(',').map(Number) : undefined,
+        A: A ? A.split(',').map(Number) : undefined,
+        closureRules: rules,
+        shocks: shocks,
+        calibration,
+      };
+      const res = await solveModel('mn1-cge', params, sam || undefined);
+      setResults(res);
+      setStep(4);
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const renderStep1 = () => (
+    <div className="space-y-4">
+      <FileUploader
+        onSamLoaded={handleSamLoaded}
+        goods={sam ? sam.goods : []}
+        factors={sam ? sam.factors : []}
+        households={sam ? sam.households : []}
+        autoPopulateNames
+        onNamesLoaded={(g, f, h) => {
+          setSam({
+            entries: [...g, ...f, ...h],
+            goods: g,
+            factors: f,
+            households: h,
+            data: sam ? sam.data : [],
+          });
+          setPrices(Array(g.length).fill(''));
+        }}
+      />
+      {sam && <SAMTable sam={sam} readOnly />}
+      {sam && (
+        <button
+          className="bg-blue-500 text-white px-4 py-2"
+          onClick={() => setStep(2)}
+        >
+          Next
+        </button>
+      )}
+    </div>
+  );
+
+  const renderStep2 = () => (
+    <div className="space-y-4">
+      {sam && (
+        <div className="space-y-2">
+          {sam.goods.map((g, i) => (
+            <div key={g} className="flex items-center gap-2">
+              <label className="w-32">Price of {g}</label>
+              <input
+                type="number"
+                value={prices[i]}
+                onChange={(e) => {
+                  const arr = [...prices];
+                  arr[i] = e.target.value;
+                  setPrices(arr);
+                }}
+                className="border p-1 flex-1"
+              />
+            </div>
+          ))}
+          <div className="flex items-center gap-2">
+            <label className="w-32">Wage rate</label>
+            <input
+              type="number"
+              value={wage}
+              onChange={(e) => setWage(e.target.value)}
+              className="border p-1 flex-1"
+            />
+          </div>
+        </div>
+      )}
+      <div className="space-y-2">
+        <div>
+          <label className="mr-4">Calibration:</label>
+          <label className="mr-2">
+            <input
+              type="radio"
+              value="auto"
+              checked={calibration === 'auto'}
+              onChange={() => setCalibration('auto')}
+            />
+            Auto
+          </label>
+          <label>
+            <input
+              type="radio"
+              value="manual"
+              checked={calibration === 'manual'}
+              onChange={() => setCalibration('manual')}
+            />
+            Manual
+          </label>
+        </div>
+        {calibration === 'manual' && (
+          <div className="space-y-2">
+            <input
+              type="text"
+              value={beta}
+              onChange={(e) => setBeta(e.target.value)}
+              placeholder="BETA values comma separated"
+              className="border p-1 w-full"
+            />
+            <input
+              type="text"
+              value={alpha}
+              onChange={(e) => setAlpha(e.target.value)}
+              placeholder="ALPHA values comma separated"
+              className="border p-1 w-full"
+            />
+            <input
+              type="text"
+              value={A}
+              onChange={(e) => setA(e.target.value)}
+              placeholder="A values comma separated"
+              className="border p-1 w-full"
+            />
+          </div>
+        )}
+      </div>
+      <div className="flex justify-between">
+        <button
+          className="px-4 py-2 border"
+          onClick={() => setStep(1)}
+        >
+          Back
+        </button>
+        <button
+          className="bg-blue-500 text-white px-4 py-2"
+          onClick={() => setStep(3)}
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+
+  const renderStep3 = () => (
+    <div className="space-y-4">
+      <div>
+        <h3 className="font-semibold mb-2">Closure Rules</h3>
+        <ClosureRuleBuilder
+          rules={rules}
+          onAdd={handleAddRule}
+          onRemove={handleRemoveRule}
+        />
+      </div>
+      <div>
+        <h3 className="font-semibold mb-2">Shocks</h3>
+        <ShockBuilder
+          shocks={shocks}
+          onAdd={handleAddShock}
+          onRemove={handleRemoveShock}
+        />
+      </div>
+      <div className="flex justify-between">
+        <button
+          className="px-4 py-2 border"
+          onClick={() => setStep(2)}
+        >
+          Back
+        </button>
+        <button
+          className="bg-blue-500 text-white px-4 py-2"
+          onClick={runModel}
+          disabled={loading}
+        >
+          {loading ? 'Running...' : 'Run Model'}
+        </button>
+      </div>
+    </div>
+  );
+
+  const renderStep4 = () => (
+    <div className="space-y-4">
+      {results && <ResultsDisplay results={results} />}
+      <button className="px-4 py-2 border" onClick={() => setStep(1)}>
+        Start Over
+      </button>
+    </div>
+  );
+
+  return (
+    <div className="max-w-3xl mx-auto p-4">
+      <h1 className="text-xl font-bold mb-4">New Project Wizard</h1>
+      {step === 1 && renderStep1()}
+      {step === 2 && renderStep2()}
+      {step === 3 && renderStep3()}
+      {step === 4 && renderStep4()}
+    </div>
+  );
+};
+
+export default ProjectWizardPage;

--- a/frontend/src/utils/templateData.ts
+++ b/frontend/src/utils/templateData.ts
@@ -60,8 +60,22 @@ const templates: ModelTemplate[] = [
       hasInvestment: true,
       description: 'Three sector Saudi economy with two household types.'
     }
-  }
-  ,
+  },
+  {
+    id: 'mn1-cge',
+    name: 'MN1 CGE Model',
+    shortDescription: 'Modular template with closure and shock builder',
+    type: 'mn1',
+    sectors: [],
+    factors: [],
+    households: [],
+    details: {
+      hasGovernment: false,
+      hasTrade: false,
+      hasInvestment: false,
+      description: 'Upload SAM, set benchmarks, and run custom shocks'
+    }
+  },
   {
     id: 'standard-cge',
     name: 'Standard CGE Model',

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -3,7 +3,7 @@ export interface ModelTemplate {
   id: string;
   name: string;
   shortDescription: string;
-  type: 'simple' | 'standard' | 'cameroon' | 'korea' | 'saudi';
+  type: 'simple' | 'standard' | 'cameroon' | 'korea' | 'saudi' | 'mn1';
   sectors: string[];
   factors: string[];
   households: string[];
@@ -24,6 +24,18 @@ export interface SAM {
   data: number[][];
 }
 
+// MN1 model helpers
+export interface ClosureRule {
+  variable: string;
+  indices: string[];
+}
+
+export interface Shock {
+  target: string;
+  indices: string[];
+  multiplier: number;
+}
+
 // Model Parameters
 export interface ModelParameters {
   alpha: number[]; // share parameter in utility function
@@ -31,6 +43,14 @@ export interface ModelParameters {
   tariff?: number[];
   indirectTax?: number[];
   incomeTax?: number[];
+  // MN1 extensions
+  prices?: number[];
+  wage?: number;
+  beta?: number[];
+  A?: number[];
+  closureRules?: ClosureRule[];
+  shocks?: Shock[];
+  calibration?: 'auto' | 'manual';
 }
 
 // Model Results


### PR DESCRIPTION
## Summary
- integrate placeholder backend endpoint for `mn1-cge`
- add MN1 template and types with closure rule & shock structures
- implement wizard page with SAM upload, benchmarks, closure rules, and shocks

## Testing
- `pytest` *(fails: No module named 'requests')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0b044f7fc832aaa6c9a5efed1e118