### PR TITLE
feat: add user projects page

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -74,6 +74,19 @@ def init_db():
             """
         )
 
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS projects (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                name TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY(user_id) REFERENCES users(id)
+            )
+            """
+        )
+
         conn.commit()
 
 
@@ -127,6 +140,36 @@ def delete_runs_for_user(user_id: int) -> None:
     with get_db_connection() as conn:
         conn.execute('DELETE FROM runs WHERE user_id=?', (user_id,))
         conn.commit()
+
+
+def insert_project(user_id: int, name: str) -> int:
+    with get_db_connection() as conn:
+        cur = conn.execute(
+            'INSERT INTO projects (user_id, name) VALUES (?, ?)',
+            (user_id, name),
+        )
+        conn.commit()
+        return cur.lastrowid
+
+
+def fetch_projects_for_user(user_id: int) -> list[Dict]:
+    with get_db_connection() as conn:
+        cur = conn.execute(
+            'SELECT id, name, created_at, updated_at FROM projects WHERE user_id=? ORDER BY created_at DESC',
+            (user_id,),
+        )
+        rows = cur.fetchall()
+        return [dict(row) for row in rows]
+
+
+def fetch_project(project_id: int) -> Optional[Dict]:
+    with get_db_connection() as conn:
+        cur = conn.execute(
+            'SELECT id, user_id, name, created_at, updated_at FROM projects WHERE id=?',
+            (project_id,),
+        )
+        row = cur.fetchone()
+        return dict(row) if row else None
 
 
 def send_contact_email(name: str, email: str, message: str):
@@ -488,6 +531,42 @@ def clear_runs():
 
     delete_runs_for_user(user_id)
     return jsonify({'message': 'Run history cleared'})
+
+
+@app.route('/projects', methods=['POST'])
+def create_project():
+    try:
+        data = parse_json_request(request)
+    except RequestValidationError as exc:
+        return jsonify({'error': exc.message}), exc.status_code
+
+    name = data.get('name')
+    user_id = data.get('userId')
+    username = data.get('username')
+    if not user_id and username:
+        user_id = get_user_id(username)
+
+    if not user_id or not name:
+        return jsonify({'error': 'Project name and valid userId or username required'}), 400
+
+    project_id = insert_project(user_id, name)
+    project = fetch_project(project_id)
+    return jsonify(project), 201
+
+
+@app.route('/projects', methods=['GET'])
+def list_projects_route():
+    username = request.args.get('username')
+    user_id = request.args.get('userId', type=int)
+
+    if not user_id and username:
+        user_id = get_user_id(username)
+
+    if not user_id:
+        return jsonify({'error': 'Valid userId or username required'}), 400
+
+    projects = fetch_projects_for_user(user_id)
+    return jsonify(projects)
 
 @app.route('/compare-scenarios', methods=['POST'])
 def compare_scenarios():

--- a/frontend/src/screens/ProjectsPage.tsx
+++ b/frontend/src/screens/ProjectsPage.tsx
@@ -1,10 +1,110 @@
-import React from 'react';
+import { useContext, useEffect, useState } from 'react';
+import { AuthContext } from '../contexts/AuthContext';
+import { createProject, listProjects } from '../utils/api';
+import { Project } from '../utils/types';
 
 const ProjectsPage = () => {
+  const { username } = useContext(AuthContext);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [showModal, setShowModal] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [sortBy, setSortBy] = useState<'updated_at' | 'created_at' | 'name'>('updated_at');
+
+  const loadProjects = async () => {
+    if (!username) return;
+    const data = await listProjects(username);
+    setProjects(data);
+  };
+
+  useEffect(() => {
+    loadProjects();
+  }, [username]);
+
+  const handleSave = async () => {
+    if (!newName.trim()) return;
+    await createProject(username, newName.trim());
+    setShowModal(false);
+    setNewName('');
+    loadProjects();
+  };
+
+  const formatDate = (str: string) => {
+    const d = new Date(str);
+    const date = d.toLocaleDateString(undefined, { month: 'long', day: 'numeric' });
+    const year = d.getFullYear();
+    const time = d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    return `${date} • ${year} - ${time}`;
+    };
+
+  const sortedProjects = [...projects].sort((a, b) => {
+    if (sortBy === 'name') {
+      return a.name.localeCompare(b.name);
+    }
+    return new Date(b[sortBy]).getTime() - new Date(a[sortBy]).getTime();
+  });
+
   return (
     <div className="max-w-4xl mx-auto my-12 p-4">
-      <h1 className="text-2xl font-bold mb-4">Projects</h1>
-      <p>Project dashboard coming soon.</p>
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-bold">Projects</h1>
+        <button className="btn btn-primary" onClick={() => setShowModal(true)}>
+          New Project
+        </button>
+      </div>
+
+      {projects.length > 0 && (
+        <div className="flex justify-end mb-4">
+          <label className="mr-2 text-sm">Sort by:</label>
+          <select
+            className="input w-40"
+            value={sortBy}
+            onChange={(e) => setSortBy(e.target.value as any)}
+          >
+            <option value="updated_at">Updated</option>
+            <option value="created_at">Created</option>
+            <option value="name">Name</option>
+          </select>
+        </div>
+      )}
+
+      {projects.length === 0 ? (
+        <div className="text-center text-darkgray/70 mt-20">
+          <p>You don't have any projects yet. Click 'New Project' to get started.</p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {sortedProjects.map((p) => (
+            <div key={p.id} className="card p-4 flex justify-between items-center">
+              <div>
+                <h2 className="text-lg font-semibold">{p.name}</h2>
+                <p className="text-sm text-darkgray/70">Created on {formatDate(p.created_at)}</p>
+                <p className="text-sm text-darkgray/70">Updated on {formatDate(p.updated_at)}</p>
+              </div>
+              <button className="btn btn-secondary">Open</button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {showModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+          <div className="card w-full max-w-md p-6">
+            <h2 className="text-xl font-bold mb-4">New Project</h2>
+            <label className="block mb-2 text-sm font-medium">Project Name</label>
+            <input
+              type="text"
+              className="input w-full mb-4"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+            />
+            <div className="flex justify-end">
+              <button className="btn btn-primary" onClick={handleSave}>
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { ModelParameters, ModelResults, SAM, ScenarioComparison } from './types';
+import { ModelParameters, ModelResults, SAM, ScenarioComparison, Project } from './types';
 
 const api = axios.create({
   baseURL: 'http://127.0.0.1:5002',
@@ -189,6 +189,23 @@ export const registerUser = async (
 export const loginUser = async (username: string, password: string) => {
   const response = await api.post('/login', { username, password });
   return response.data as { message: string; username: string; avatar: string };
+};
+
+export const createProject = async (
+  username: string | undefined,
+  name: string
+): Promise<Project | undefined> => {
+  if (!username) return;
+  const response = await api.post('/projects', { username, name });
+  return response.data as Project;
+};
+
+export const listProjects = async (
+  username: string | undefined
+): Promise<Project[]> => {
+  if (!username) return [] as Project[];
+  const response = await api.get('/projects', { params: { username } });
+  return response.data as Project[];
 };
 
 export default api;

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -139,3 +139,11 @@ export interface ScenarioComparison {
     };
   };
 }
+
+// User Projects
+export interface Project {
+  id: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## Summary
- add backend support for storing and listing user projects
- expose project APIs in frontend utilities
- implement Projects page with creation modal and sorting

## Testing
- `npm --prefix frontend run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react" even after attempted install)*
- `cd backend && pytest` *(fails: ModuleNotFoundError: No module named 'requests'; pip install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d51fd55c832ab60033fb4b3f9e22