### PR TITLE
Improve Projects UX and enable deletions

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -172,6 +172,12 @@ def fetch_project(project_id: int) -> Optional[Dict]:
         return dict(row) if row else None
 
 
+def delete_project(project_id: int) -> None:
+    with get_db_connection() as conn:
+        conn.execute('DELETE FROM projects WHERE id=?', (project_id,))
+        conn.commit()
+
+
 def send_contact_email(name: str, email: str, message: str):
     smtp_server = os.environ.get('SMTP_SERVER', 'localhost')
     smtp_port = int(os.environ.get('SMTP_PORT', 25))
@@ -567,6 +573,25 @@ def list_projects_route():
 
     projects = fetch_projects_for_user(user_id)
     return jsonify(projects)
+
+
+@app.route('/projects/<int:project_id>', methods=['DELETE'])
+def delete_project_route(project_id: int):
+    username = request.args.get('username')
+    user_id = request.args.get('userId', type=int)
+
+    if not user_id and username:
+        user_id = get_user_id(username)
+
+    if not user_id:
+        return jsonify({'error': 'Valid userId or username required'}), 400
+
+    project = fetch_project(project_id)
+    if not project or project['user_id'] != user_id:
+        return jsonify({'error': 'Project not found'}), 404
+
+    delete_project(project_id)
+    return jsonify({'message': 'Project deleted'})
 
 @app.route('/compare-scenarios', methods=['POST'])
 def compare_scenarios():

--- a/frontend/src/screens/ProjectsPage.tsx
+++ b/frontend/src/screens/ProjectsPage.tsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useState } from 'react';
 import { AuthContext } from '../contexts/AuthContext';
-import { createProject, listProjects } from '../utils/api';
+import { createProject, listProjects, deleteProject } from '../utils/api';
 import { Project } from '../utils/types';
 
 const ProjectsPage = () => {
@@ -9,6 +9,7 @@ const ProjectsPage = () => {
   const [showModal, setShowModal] = useState(false);
   const [newName, setNewName] = useState('');
   const [sortBy, setSortBy] = useState<'updated_at' | 'created_at' | 'name'>('updated_at');
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
 
   const loadProjects = async () => {
     if (!username) return;
@@ -38,10 +39,23 @@ const ProjectsPage = () => {
 
   const sortedProjects = [...projects].sort((a, b) => {
     if (sortBy === 'name') {
-      return a.name.localeCompare(b.name);
+      return sortOrder === 'asc'
+        ? a.name.localeCompare(b.name)
+        : b.name.localeCompare(a.name);
     }
-    return new Date(b[sortBy]).getTime() - new Date(a[sortBy]).getTime();
+    return sortOrder === 'asc'
+      ? new Date(a[sortBy]).getTime() - new Date(b[sortBy]).getTime()
+      : new Date(b[sortBy]).getTime() - new Date(a[sortBy]).getTime();
   });
+
+  const toggleSortOrder = () =>
+    setSortOrder((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+
+  const handleDelete = async (id: number) => {
+    if (!window.confirm('Are you sure you want to delete this project?')) return;
+    await deleteProject(username, id);
+    loadProjects();
+  };
 
   return (
     <div className="max-w-4xl mx-auto my-12 p-4">
@@ -53,17 +67,26 @@ const ProjectsPage = () => {
       </div>
 
       {projects.length > 0 && (
-        <div className="flex justify-end mb-4">
-          <label className="mr-2 text-sm">Sort by:</label>
-          <select
-            className="input w-40"
-            value={sortBy}
-            onChange={(e) => setSortBy(e.target.value as any)}
-          >
-            <option value="updated_at">Updated</option>
-            <option value="created_at">Created</option>
-            <option value="name">Name</option>
-          </select>
+        <div className="flex items-center justify-end mb-4 space-x-2">
+          <label className="text-sm">Sort by:</label>
+          <div className="flex items-center">
+            <select
+              className="input h-8 text-sm w-40"
+              value={sortBy}
+              onChange={(e) => setSortBy(e.target.value as any)}
+            >
+              <option value="updated_at">Updated</option>
+              <option value="created_at">Created</option>
+              <option value="name">Name</option>
+            </select>
+            <button
+              className="ml-1 p-1 text-sm"
+              onClick={toggleSortOrder}
+              aria-label="Toggle sort order"
+            >
+              {sortOrder === 'asc' ? '▲' : '▼'}
+            </button>
+          </div>
         </div>
       )}
 
@@ -74,13 +97,30 @@ const ProjectsPage = () => {
       ) : (
         <div className="space-y-4">
           {sortedProjects.map((p) => (
-            <div key={p.id} className="card p-4 flex justify-between items-center">
+            <div
+              key={p.id}
+              className="card p-4 flex justify-between items-center border border-midgray shadow-sm"
+            >
               <div>
-                <h2 className="text-lg font-semibold">{p.name}</h2>
+                <div className="flex items-center">
+                  <h2 className="text-lg font-semibold">{p.name}</h2>
+                  <span className="ml-2 bg-success text-white text-xs px-2 py-1 rounded">
+                    Active
+                  </span>
+                </div>
                 <p className="text-sm text-darkgray/70">Created on {formatDate(p.created_at)}</p>
                 <p className="text-sm text-darkgray/70">Updated on {formatDate(p.updated_at)}</p>
               </div>
-              <button className="btn btn-secondary">Open</button>
+              <div className="flex items-center space-x-2">
+                <button className="btn btn-primary">Open</button>
+                <button
+                  className="text-danger hover:text-danger/80"
+                  onClick={() => handleDelete(p.id)}
+                  aria-label="Delete project"
+                >
+                  🗑️
+                </button>
+              </div>
             </div>
           ))}
         </div>

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -208,4 +208,12 @@ export const listProjects = async (
   return response.data as Project[];
 };
 
+export const deleteProject = async (
+  username: string | undefined,
+  projectId: number
+): Promise<void> => {
+  if (!username) return;
+  await api.delete(`/projects/${projectId}`, { params: { username } });
+};
+
 export default api;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -7,13 +7,14 @@ export default {
   theme: {
     extend: {
       colors: {
-        primary: "#2563eb",
+        primary: "#1d4ed8",
         secondary: "#9333ea",
         neutral: "#f9fafb",
         midgray: "#d1d5db",
         darkgray: "#1f2937",
         success: "#10b981",
         warning: "#f59e0b",
+        danger: "#ef4444",
       },
       keyframes: {
         fadeInUp: {


### PR DESCRIPTION
## Summary
- refine Project list with sort direction toggle, active badge, and delete control
- allow users to remove their own projects through a new API endpoint
- adopt stronger color palette with darker primary and danger hues

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react")*
- `python -m py_compile backend/app.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_68a0e4a477b4832a97ca14dee6c517d7