### PR TITLE
Add project archiving and status filtering

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -80,12 +80,19 @@ def init_db():
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 user_id INTEGER NOT NULL,
                 name TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'open',
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 FOREIGN KEY(user_id) REFERENCES users(id)
             )
             """
         )
+
+        # ensure status column exists for older databases
+        cur = conn.execute("PRAGMA table_info(projects)")
+        columns = [row[1] for row in cur.fetchall()]
+        if 'status' not in columns:
+            conn.execute("ALTER TABLE projects ADD COLUMN status TEXT NOT NULL DEFAULT 'open'")
 
         conn.commit()
 
@@ -145,8 +152,8 @@ def delete_runs_for_user(user_id: int) -> None:
 def insert_project(user_id: int, name: str) -> int:
     with get_db_connection() as conn:
         cur = conn.execute(
-            'INSERT INTO projects (user_id, name) VALUES (?, ?)',
-            (user_id, name),
+            'INSERT INTO projects (user_id, name, status) VALUES (?, ?, ?)',
+            (user_id, name, 'open'),
         )
         conn.commit()
         return cur.lastrowid
@@ -155,7 +162,7 @@ def insert_project(user_id: int, name: str) -> int:
 def fetch_projects_for_user(user_id: int) -> list[Dict]:
     with get_db_connection() as conn:
         cur = conn.execute(
-            'SELECT id, name, created_at, updated_at FROM projects WHERE user_id=? ORDER BY created_at DESC',
+            'SELECT id, name, status, created_at, updated_at FROM projects WHERE user_id=? ORDER BY created_at DESC',
             (user_id,),
         )
         rows = cur.fetchall()
@@ -165,11 +172,20 @@ def fetch_projects_for_user(user_id: int) -> list[Dict]:
 def fetch_project(project_id: int) -> Optional[Dict]:
     with get_db_connection() as conn:
         cur = conn.execute(
-            'SELECT id, user_id, name, created_at, updated_at FROM projects WHERE id=?',
+            'SELECT id, user_id, name, status, created_at, updated_at FROM projects WHERE id=?',
             (project_id,),
         )
         row = cur.fetchone()
         return dict(row) if row else None
+
+
+def update_project_status(project_id: int, status: str) -> None:
+    with get_db_connection() as conn:
+        conn.execute(
+            'UPDATE projects SET status=?, updated_at=CURRENT_TIMESTAMP WHERE id=?',
+            (status, project_id),
+        )
+        conn.commit()
 
 
 def delete_project(project_id: int) -> None:
@@ -573,6 +589,34 @@ def list_projects_route():
 
     projects = fetch_projects_for_user(user_id)
     return jsonify(projects)
+
+
+@app.route('/projects/<int:project_id>', methods=['PATCH'])
+def update_project_route(project_id: int):
+    try:
+        data = parse_json_request(request)
+    except RequestValidationError as exc:
+        return jsonify({'error': exc.message}), exc.status_code
+
+    username = data.get('username')
+    user_id = data.get('userId')
+    if not user_id and username:
+        user_id = get_user_id(username)
+
+    if not user_id:
+        return jsonify({'error': 'Valid userId or username required'}), 400
+
+    project = fetch_project(project_id)
+    if not project or project['user_id'] != user_id:
+        return jsonify({'error': 'Project not found'}), 404
+
+    status = data.get('status')
+    if status not in ['open', 'archived']:
+        return jsonify({'error': 'Invalid status'}), 400
+
+    update_project_status(project_id, status)
+    project = fetch_project(project_id)
+    return jsonify(project)
 
 
 @app.route('/projects/<int:project_id>', methods=['DELETE'])

--- a/frontend/src/screens/ProjectsPage.tsx
+++ b/frontend/src/screens/ProjectsPage.tsx
@@ -1,15 +1,18 @@
 import { useContext, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { AuthContext } from '../contexts/AuthContext';
-import { createProject, listProjects, deleteProject } from '../utils/api';
+import { createProject, listProjects, deleteProject, updateProjectStatus } from '../utils/api';
 import { Project } from '../utils/types';
 
 const ProjectsPage = () => {
   const { username } = useContext(AuthContext);
+  const navigate = useNavigate();
   const [projects, setProjects] = useState<Project[]>([]);
   const [showModal, setShowModal] = useState(false);
   const [newName, setNewName] = useState('');
   const [sortBy, setSortBy] = useState<'updated_at' | 'created_at' | 'name'>('updated_at');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+  const [filter, setFilter] = useState<'all' | 'open' | 'archived'>('open');
 
   const loadProjects = async () => {
     if (!username) return;
@@ -57,6 +60,15 @@ const ProjectsPage = () => {
     loadProjects();
   };
 
+  const handleArchive = async (id: number) => {
+    await updateProjectStatus(username, id, 'archived');
+    loadProjects();
+  };
+
+  const handleOpen = (id: number) => {
+    navigate(`/projects/${id}`);
+  };
+
   return (
     <div className="max-w-4xl mx-auto my-12 p-4">
       <div className="flex justify-between items-center mb-4">
@@ -67,27 +79,42 @@ const ProjectsPage = () => {
       </div>
 
       {projects.length > 0 && (
-        <div className="flex items-center justify-end mb-4 space-x-2">
-          <label className="text-sm">Sort by:</label>
-          <div className="flex items-center">
-            <select
-              className="input h-8 text-sm w-40"
-              value={sortBy}
-              onChange={(e) => setSortBy(e.target.value as any)}
-            >
-              <option value="updated_at">Updated</option>
-              <option value="created_at">Created</option>
-              <option value="name">Name</option>
-            </select>
-            <button
-              className="ml-1 p-1 text-sm"
-              onClick={toggleSortOrder}
-              aria-label="Toggle sort order"
-            >
-              {sortOrder === 'asc' ? '▲' : '▼'}
-            </button>
+        <>
+          <div className="flex space-x-4 mb-4">
+            {['all', 'open', 'archived'].map((t) => (
+              <button
+                key={t}
+                className={`pb-1 text-sm border-b-2 ${
+                  filter === t ? 'border-primary text-primary' : 'border-transparent text-darkgray/70'
+                }`}
+                onClick={() => setFilter(t as 'all' | 'open' | 'archived')}
+              >
+                {t === 'all' ? 'All' : t === 'open' ? 'Open' : 'Archived'}
+              </button>
+            ))}
           </div>
-        </div>
+          <div className="flex items-center justify-end mb-4 space-x-2">
+            <label className="text-sm">Sort by:</label>
+            <div className="flex items-center">
+              <select
+                className="input text-sm w-40 px-2 py-1"
+                value={sortBy}
+                onChange={(e) => setSortBy(e.target.value as any)}
+              >
+                <option value="updated_at">Updated</option>
+                <option value="created_at">Created</option>
+                <option value="name">Name</option>
+              </select>
+              <button
+                className="ml-1 p-1 text-sm"
+                onClick={toggleSortOrder}
+                aria-label="Toggle sort order"
+              >
+                {sortOrder === 'asc' ? '▲' : '▼'}
+              </button>
+            </div>
+          </div>
+        </>
       )}
 
       {projects.length === 0 ? (
@@ -96,7 +123,15 @@ const ProjectsPage = () => {
         </div>
       ) : (
         <div className="space-y-4">
-          {sortedProjects.map((p) => (
+          {sortedProjects
+            .filter((p) =>
+              filter === 'all'
+                ? true
+                : filter === 'open'
+                ? p.status !== 'archived'
+                : p.status === 'archived'
+            )
+            .map((p) => (
             <div
               key={p.id}
               className="card p-4 flex justify-between items-center border border-midgray shadow-sm"
@@ -105,17 +140,35 @@ const ProjectsPage = () => {
                 <div className="flex items-center">
                   <h2 className="text-lg font-semibold">{p.name}</h2>
                   <span className="ml-2 bg-success text-white text-xs px-2 py-1 rounded">
-                    Active
+                    {p.status === 'archived' ? 'Archived' : 'Active'}
                   </span>
                 </div>
                 <p className="text-sm text-darkgray/70">Created on {formatDate(p.created_at)}</p>
                 <p className="text-sm text-darkgray/70">Updated on {formatDate(p.updated_at)}</p>
               </div>
               <div className="flex items-center space-x-2">
-                <button className="btn btn-primary">Open</button>
                 <button
-                  className="text-danger hover:text-danger/80"
+                  className="p-1 text-lg hover:opacity-80"
+                  onClick={() => handleOpen(p.id)}
+                  title="Open Project"
+                  aria-label="Open project"
+                >
+                  📂
+                </button>
+                {p.status !== 'archived' && (
+                  <button
+                    className="p-1 text-lg hover:opacity-80"
+                    onClick={() => handleArchive(p.id)}
+                    title="Archive Project"
+                    aria-label="Archive project"
+                  >
+                    📥
+                  </button>
+                )}
+                <button
+                  className="p-1 text-lg text-danger hover:opacity-80"
                   onClick={() => handleDelete(p.id)}
+                  title="Delete Project"
                   aria-label="Delete project"
                 >
                   🗑️

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -208,6 +208,19 @@ export const listProjects = async (
   return response.data as Project[];
 };
 
+export const updateProjectStatus = async (
+  username: string | undefined,
+  projectId: number,
+  status: 'open' | 'archived'
+): Promise<Project | undefined> => {
+  if (!username) return;
+  const response = await api.patch(`/projects/${projectId}`, {
+    username,
+    status,
+  });
+  return response.data as Project;
+};
+
 export const deleteProject = async (
   username: string | undefined,
   projectId: number

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -144,6 +144,7 @@ export interface ScenarioComparison {
 export interface Project {
   id: number;
   name: string;
+  status: 'open' | 'archived';
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary
- allow projects to be archived with new status column and PATCH endpoint
- replace project action buttons with open/archive/delete icons and filter tabs
- include project status in frontend types and API

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: ESLint couldn't find eslint-plugin-react)*
- `npm install eslint-plugin-react@latest --save-dev` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e6fbe270832aac9febfc7d19d455