### PR TITLE
Allow restoring archived projects from Projects page

### DIFF
--- a/frontend/src/screens/ProjectsPage.tsx
+++ b/frontend/src/screens/ProjectsPage.tsx
@@ -65,6 +65,11 @@ const ProjectsPage = () => {
     loadProjects();
   };
 
+  const handleRestore = async (id: number) => {
+    await updateProjectStatus(username, id, 'open');
+    loadProjects();
+  };
+
   const handleOpen = (id: number) => {
     navigate(`/projects/${id}`);
   };
@@ -106,7 +111,7 @@ const ProjectsPage = () => {
                 <option value="name">Name</option>
               </select>
               <button
-                className="ml-1 p-1 text-sm"
+                className="ml-0 p-1 text-sm"
                 onClick={toggleSortOrder}
                 aria-label="Toggle sort order"
               >
@@ -139,14 +144,18 @@ const ProjectsPage = () => {
               <div>
                 <div className="flex items-center">
                   <h2 className="text-lg font-semibold">{p.name}</h2>
-                  <span className="ml-2 bg-success text-white text-xs px-2 py-1 rounded">
+                  <span
+                    className={`ml-2 text-white text-xs px-2 py-1 rounded ${
+                      p.status === 'archived' ? 'bg-red-800' : 'bg-green-800'
+                    }`}
+                  >
                     {p.status === 'archived' ? 'Archived' : 'Active'}
                   </span>
                 </div>
                 <p className="text-sm text-darkgray/70">Created on {formatDate(p.created_at)}</p>
                 <p className="text-sm text-darkgray/70">Updated on {formatDate(p.updated_at)}</p>
               </div>
-              <div className="flex items-center space-x-2">
+              <div className="flex items-center space-x-3">
                 <button
                   className="p-1 text-lg hover:opacity-80"
                   onClick={() => handleOpen(p.id)}
@@ -155,7 +164,16 @@ const ProjectsPage = () => {
                 >
                   📂
                 </button>
-                {p.status !== 'archived' && (
+                {p.status === 'archived' ? (
+                  <button
+                    className="p-1 text-lg hover:opacity-80"
+                    onClick={() => handleRestore(p.id)}
+                    title="Restore to Active"
+                    aria-label="Restore project"
+                  >
+                    ♻️
+                  </button>
+                ) : (
                   <button
                     className="p-1 text-lg hover:opacity-80"
                     onClick={() => handleArchive(p.id)}


### PR DESCRIPTION
## Summary
- Differentiate project status labels with dark red for archived and dark green for active
- Replace archive icon with restore control to reactivate projects
- Slightly increase icon spacing and adjust sort arrow alignment

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react"; attempts to install plugin returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a0eaa19b5c832a91b673fe4be75865