### PR TITLE
feat: enhance project management UI and data

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -80,6 +80,8 @@ def init_db():
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 user_id INTEGER NOT NULL,
                 name TEXT NOT NULL,
+                description TEXT,
+                template TEXT,
                 status TEXT NOT NULL DEFAULT 'open',
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -88,11 +90,17 @@ def init_db():
             """
         )
 
-        # ensure status column exists for older databases
+        # ensure new columns exist for older databases
         cur = conn.execute("PRAGMA table_info(projects)")
         columns = [row[1] for row in cur.fetchall()]
+        if 'description' not in columns:
+            conn.execute("ALTER TABLE projects ADD COLUMN description TEXT")
+        if 'template' not in columns:
+            conn.execute("ALTER TABLE projects ADD COLUMN template TEXT")
         if 'status' not in columns:
-            conn.execute("ALTER TABLE projects ADD COLUMN status TEXT NOT NULL DEFAULT 'open'")
+            conn.execute(
+                "ALTER TABLE projects ADD COLUMN status TEXT NOT NULL DEFAULT 'open'"
+            )
 
         conn.commit()
 
@@ -149,11 +157,13 @@ def delete_runs_for_user(user_id: int) -> None:
         conn.commit()
 
 
-def insert_project(user_id: int, name: str) -> int:
+def insert_project(
+    user_id: int, name: str, description: str = '', template: str = 'A'
+) -> int:
     with get_db_connection() as conn:
         cur = conn.execute(
-            'INSERT INTO projects (user_id, name, status) VALUES (?, ?, ?)',
-            (user_id, name, 'open'),
+            'INSERT INTO projects (user_id, name, description, template, status) VALUES (?, ?, ?, ?, ?)',
+            (user_id, name, description, template, 'open'),
         )
         conn.commit()
         return cur.lastrowid
@@ -162,7 +172,7 @@ def insert_project(user_id: int, name: str) -> int:
 def fetch_projects_for_user(user_id: int) -> list[Dict]:
     with get_db_connection() as conn:
         cur = conn.execute(
-            'SELECT id, name, status, created_at, updated_at FROM projects WHERE user_id=? ORDER BY created_at DESC',
+            'SELECT id, name, description, template, status, created_at, updated_at FROM projects WHERE user_id=? ORDER BY created_at DESC',
             (user_id,),
         )
         rows = cur.fetchall()
@@ -172,7 +182,7 @@ def fetch_projects_for_user(user_id: int) -> list[Dict]:
 def fetch_project(project_id: int) -> Optional[Dict]:
     with get_db_connection() as conn:
         cur = conn.execute(
-            'SELECT id, user_id, name, status, created_at, updated_at FROM projects WHERE id=?',
+            'SELECT id, user_id, name, description, template, status, created_at, updated_at FROM projects WHERE id=?',
             (project_id,),
         )
         row = cur.fetchone()
@@ -563,6 +573,8 @@ def create_project():
         return jsonify({'error': exc.message}), exc.status_code
 
     name = data.get('name')
+    description = data.get('description', '')
+    template = data.get('template', 'A')
     user_id = data.get('userId')
     username = data.get('username')
     if not user_id and username:
@@ -571,7 +583,7 @@ def create_project():
     if not user_id or not name:
         return jsonify({'error': 'Project name and valid userId or username required'}), 400
 
-    project_id = insert_project(user_id, name)
+    project_id = insert_project(user_id, name, description, template)
     project = fetch_project(project_id)
     return jsonify(project), 201
 

--- a/frontend/src/screens/ProjectsPage.tsx
+++ b/frontend/src/screens/ProjectsPage.tsx
@@ -10,6 +10,8 @@ const ProjectsPage = () => {
   const [projects, setProjects] = useState<Project[]>([]);
   const [showModal, setShowModal] = useState(false);
   const [newName, setNewName] = useState('');
+  const [newDescription, setNewDescription] = useState('');
+  const [newTemplate, setNewTemplate] = useState('A');
   const [sortBy, setSortBy] = useState<'updated_at' | 'created_at' | 'name'>('updated_at');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
   const [filter, setFilter] = useState<'all' | 'open' | 'archived'>('open');
@@ -26,19 +28,27 @@ const ProjectsPage = () => {
 
   const handleSave = async () => {
     if (!newName.trim()) return;
-    await createProject(username, newName.trim());
+    await createProject(
+      username,
+      newName.trim(),
+      newDescription.trim(),
+      newTemplate
+    );
     setShowModal(false);
     setNewName('');
+    setNewDescription('');
+    setNewTemplate('A');
     loadProjects();
   };
 
   const formatDate = (str: string) => {
     const d = new Date(str);
-    const date = d.toLocaleDateString(undefined, { month: 'long', day: 'numeric' });
-    const year = d.getFullYear();
+    const day = d.getDate().toString().padStart(2, '0');
+    const month = (d.getMonth() + 1).toString().padStart(2, '0');
+    const year = d.getFullYear().toString().slice(-2);
     const time = d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-    return `${date} • ${year} - ${time}`;
-    };
+    return `${day}/${month}/${year} • ${time}`;
+  };
 
   const sortedProjects = [...projects].sort((a, b) => {
     if (sortBy === 'name') {
@@ -99,25 +109,23 @@ const ProjectsPage = () => {
             ))}
           </div>
           <div className="flex items-center justify-end mb-4 space-x-2">
+            <button
+              className="p-1 text-sm"
+              onClick={toggleSortOrder}
+              aria-label="Toggle sort order"
+            >
+              {sortOrder === 'asc' ? '▲' : '▼'}
+            </button>
             <label className="text-sm">Sort by:</label>
-            <div className="flex items-center">
-              <select
-                className="input text-sm w-40 px-2 py-1"
-                value={sortBy}
-                onChange={(e) => setSortBy(e.target.value as any)}
-              >
-                <option value="updated_at">Updated</option>
-                <option value="created_at">Created</option>
-                <option value="name">Name</option>
-              </select>
-              <button
-                className="ml-0 p-1 text-sm"
-                onClick={toggleSortOrder}
-                aria-label="Toggle sort order"
-              >
-                {sortOrder === 'asc' ? '▲' : '▼'}
-              </button>
-            </div>
+            <select
+              className="input text-sm w-40 px-2 py-1"
+              value={sortBy}
+              onChange={(e) => setSortBy(e.target.value as any)}
+            >
+              <option value="updated_at">Updated</option>
+              <option value="created_at">Created</option>
+              <option value="name">Name</option>
+            </select>
           </div>
         </>
       )}
@@ -137,63 +145,77 @@ const ProjectsPage = () => {
                 : p.status === 'archived'
             )
             .map((p) => (
-            <div
-              key={p.id}
-              className="card p-4 flex justify-between items-center border border-midgray shadow-sm"
-            >
-              <div>
-                <div className="flex items-center">
-                  <h2 className="text-lg font-semibold">{p.name}</h2>
-                  <span
-                    className={`ml-2 text-white text-xs px-2 py-1 rounded ${
-                      p.status === 'archived' ? 'bg-red-800' : 'bg-green-800'
-                    }`}
-                  >
-                    {p.status === 'archived' ? 'Archived' : 'Active'}
-                  </span>
+              <div
+                key={p.id}
+                className="card p-4 border border-midgray shadow-sm flex flex-col"
+              >
+                <div className="flex justify-between">
+                  <div>
+                    <div className="flex items-center">
+                      <h2 className="text-lg font-semibold">{p.name}</h2>
+                      <span
+                        className={`ml-2 inline-flex items-center text-white text-xs px-2 py-0.5 rounded ${
+                          p.status === 'archived' ? 'bg-red-800' : 'bg-green-800'
+                        }`}
+                      >
+                        {p.status === 'archived' ? 'Archived' : 'Active'}
+                      </span>
+                    </div>
+                    <p className="text-sm">
+                      <span className="font-bold">Description:</span> {p.description || ''}
+                    </p>
+                    <p className="text-sm">
+                      <span className="font-bold">Template:</span> {p.template}
+                    </p>
+                  </div>
+                  <div className="flex items-start space-x-3">
+                    <button
+                      className="p-1 text-lg hover:opacity-80"
+                      onClick={() => handleOpen(p.id)}
+                      title="Open Project"
+                      aria-label="Open project"
+                    >
+                      📂
+                    </button>
+                    {p.status === 'archived' ? (
+                      <button
+                        className="p-1 text-lg hover:opacity-80"
+                        onClick={() => handleRestore(p.id)}
+                        title="Restore to Active"
+                        aria-label="Restore project"
+                      >
+                        ♻️
+                      </button>
+                    ) : (
+                      <button
+                        className="p-1 text-lg hover:opacity-80"
+                        onClick={() => handleArchive(p.id)}
+                        title="Archive Project"
+                        aria-label="Archive project"
+                      >
+                        📥
+                      </button>
+                    )}
+                    <button
+                      className="p-1 text-lg text-danger hover:opacity-80"
+                      onClick={() => handleDelete(p.id)}
+                      title="Delete Project"
+                      aria-label="Delete project"
+                    >
+                      🗑️
+                    </button>
+                  </div>
                 </div>
-                <p className="text-sm text-darkgray/70">Created on {formatDate(p.created_at)}</p>
-                <p className="text-sm text-darkgray/70">Updated on {formatDate(p.updated_at)}</p>
+                <div className="mt-4 text-xs text-darkgray/70">
+                  <p>
+                    <span className="font-bold">Created on:</span> {formatDate(p.created_at)}
+                  </p>
+                  <p>
+                    <span className="font-bold">Updated on:</span> {formatDate(p.updated_at)}
+                  </p>
+                </div>
               </div>
-              <div className="flex items-center space-x-3">
-                <button
-                  className="p-1 text-lg hover:opacity-80"
-                  onClick={() => handleOpen(p.id)}
-                  title="Open Project"
-                  aria-label="Open project"
-                >
-                  📂
-                </button>
-                {p.status === 'archived' ? (
-                  <button
-                    className="p-1 text-lg hover:opacity-80"
-                    onClick={() => handleRestore(p.id)}
-                    title="Restore to Active"
-                    aria-label="Restore project"
-                  >
-                    ♻️
-                  </button>
-                ) : (
-                  <button
-                    className="p-1 text-lg hover:opacity-80"
-                    onClick={() => handleArchive(p.id)}
-                    title="Archive Project"
-                    aria-label="Archive project"
-                  >
-                    📥
-                  </button>
-                )}
-                <button
-                  className="p-1 text-lg text-danger hover:opacity-80"
-                  onClick={() => handleDelete(p.id)}
-                  title="Delete Project"
-                  aria-label="Delete project"
-                >
-                  🗑️
-                </button>
-              </div>
-            </div>
-          ))}
+            ))}
         </div>
       )}
 
@@ -208,6 +230,22 @@ const ProjectsPage = () => {
               value={newName}
               onChange={(e) => setNewName(e.target.value)}
             />
+            <label className="block mb-2 text-sm font-medium">Description (optional)</label>
+            <textarea
+              className="input w-full mb-4"
+              value={newDescription}
+              onChange={(e) => setNewDescription(e.target.value)}
+            />
+            <label className="block mb-2 text-sm font-medium">Template</label>
+            <select
+              className="input w-full mb-4"
+              value={newTemplate}
+              onChange={(e) => setNewTemplate(e.target.value)}
+            >
+              <option value="A">A</option>
+              <option value="B">B</option>
+              <option value="C">C</option>
+            </select>
             <div className="flex justify-end">
               <button className="btn btn-primary" onClick={handleSave}>
                 Save

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -193,10 +193,17 @@ export const loginUser = async (username: string, password: string) => {
 
 export const createProject = async (
   username: string | undefined,
-  name: string
+  name: string,
+  description?: string,
+  template?: string
 ): Promise<Project | undefined> => {
   if (!username) return;
-  const response = await api.post('/projects', { username, name });
+  const response = await api.post('/projects', {
+    username,
+    name,
+    description,
+    template,
+  });
   return response.data as Project;
 };
 

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -144,6 +144,8 @@ export interface ScenarioComparison {
 export interface Project {
   id: number;
   name: string;
+  description?: string;
+  template?: string;
   status: 'open' | 'archived';
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## Summary
- add description and template fields when creating projects and display them in the project list
- move sorting arrow ahead of "Sort by" label and tidy card layout with footer timestamps
- extend backend project schema for description and template

## Testing
- `npm run lint` *(fails: missing eslint-plugin-react; registry access forbidden)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests'; pip install blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ef0cae84832a93e0e94c20425cef