### PR TITLE
Add benchmark price inputs and resize welcome header

### DIFF
--- a/frontend/src/screens/ProjectBuilderPage.tsx
+++ b/frontend/src/screens/ProjectBuilderPage.tsx
@@ -9,6 +9,8 @@ const ProjectBuilderPage = () => {
   const [consumers, setConsumers] = useState(1);
   const [goodsNames, setGoodsNames] = useState<string[]>(['IND1', 'IND2']);
   const [consumerNames, setConsumerNames] = useState<string[]>(['HH1']);
+  const [goodsPrices, setGoodsPrices] = useState<number[]>([1, 1]);
+  const [wageRate, setWageRate] = useState(1);
   const factorNames = ['LAB', 'CAP'];
   const [useSamNames, setUseSamNames] = useState(true);
   const [sam, setSam] = useState<SAM | null>(null);
@@ -65,19 +67,32 @@ const ProjectBuilderPage = () => {
     );
   };
 
+  const adjustPriceLength = (arr: number[], len: number) => {
+    const copy = [...arr];
+    if (copy.length < len) {
+      for (let i = copy.length; i < len; i++) copy.push(1);
+    } else if (copy.length > len) {
+      copy.length = len;
+    }
+    return copy;
+  };
+
+  useEffect(() => {
+    setGoodsPrices((prev) => adjustPriceLength(prev, industries));
+  }, [industries]);
+
   return (
     <div
-      className="max-w-4xl mx-auto my-12 p-4 space-y-8"
+      className="max-w-2xl mx-auto my-12 p-4 space-y-8"
       data-project-id={projectId}
     >
-      <div className="bg-[#2F3A4A] text-white rounded-lg p-8 text-center shadow-lg">
-        <h1 className="text-3xl font-bold mb-4">
+      <div className="bg-[#2F3A4A] text-white rounded-lg p-6 text-center shadow-lg">
+        <h1 className="text-2xl font-bold mb-2">
           Welcome to your Model Builder!
         </h1>
-        <p className="mb-6">
+        <p>
           Let's help you set up and run your CGE model step-by-step.
         </p>
-        <button className="btn btn-primary">Start Building</button>
       </div>
 
       <section>
@@ -142,11 +157,11 @@ const ProjectBuilderPage = () => {
             </label>
           </div>
 
-          {!useSamNames && (
-            <div className="space-y-4">
-              <div>
-                <label className="block mb-1 font-medium">
-                  Industry Names (comma separated)
+      {!useSamNames && (
+        <div className="space-y-4">
+          <div>
+            <label className="block mb-1 font-medium">
+              Industry Names (comma separated)
                 </label>
                 <input
                   type="text"
@@ -175,9 +190,77 @@ const ProjectBuilderPage = () => {
                 {consumerError && (
                   <p className="mt-1 text-xs text-danger">{consumerError}</p>
                 )}
-              </div>
-            </div>
-          )}
+          </div>
+        </div>
+      )}
+    </div>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold text-[#2F3A4A] mb-4">
+          2. Benchmark Prices
+        </h2>
+        <div className="bg-white p-6 rounded-lg shadow-md space-y-6">
+          <div>
+            <label className="block mb-2 font-medium">Price of goods (PO)</label>
+            <table className="w-full text-left">
+              <thead>
+                <tr>
+                  <th className="pb-2">Industry</th>
+                  <th className="pb-2">Benchmark Price (PO)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {goodsNames.map((name, idx) => (
+                  <tr key={name} className="align-top">
+                    <td className="py-2 pr-4">{name}</td>
+                    <td className="py-2">
+                      <input
+                        type="number"
+                        step="any"
+                        className={`input w-full ${
+                          goodsPrices[idx] > 0
+                            ? ''
+                            : 'border-danger focus:ring-danger'
+                        }`}
+                        value={goodsPrices[idx]}
+                        placeholder="Enter price (PO)"
+                        onChange={(e) => {
+                          const arr = [...goodsPrices];
+                          arr[idx] = parseFloat(e.target.value);
+                          setGoodsPrices(arr);
+                        }}
+                      />
+                      {goodsPrices[idx] > 0 ? null : (
+                        <p className="mt-1 text-xs text-danger">
+                          Enter a positive number
+                        </p>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div>
+            <label className="block mb-2 font-medium">Wage rate (WO)</label>
+            <input
+              type="number"
+              step="any"
+              className={`input w-full ${
+                wageRate > 0 ? '' : 'border-danger focus:ring-danger'
+              }`}
+              value={wageRate}
+              placeholder="Enter wage rate (WO)"
+              onChange={(e) => setWageRate(parseFloat(e.target.value))}
+            />
+            {wageRate > 0 ? null : (
+              <p className="mt-1 text-xs text-danger">Enter a positive number</p>
+            )}
+            <p className="mt-1 text-xs text-gray-500">
+              The wage rate represents the price of labor. Default = 1.0
+            </p>
+          </div>
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- Slim welcome card by reducing width, padding, and removing the extra button
- Add benchmark price table and wage rate input with basic validation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find plugin "eslint-plugin-react")*
- `npm install` *(fails: 403 Forbidden for @heroicons/react)*

------
https://chatgpt.com/codex/tasks/task_e_68a18811bae4832a9a21808d823aa28f