### PR TITLE
Add calibration, closure, and shock configuration to project builder

### DIFF
--- a/frontend/src/components/ClosureRuleBuilder.tsx
+++ b/frontend/src/components/ClosureRuleBuilder.tsx
@@ -3,22 +3,36 @@ import { ClosureRule } from '../utils/types';
 
 interface Props {
   rules: ClosureRule[];
+  goods: string[];
+  consumers: string[];
   onAdd: (rule: ClosureRule) => void;
   onRemove: (index: number) => void;
 }
 
-const ClosureRuleBuilder = ({ rules, onAdd, onRemove }: Props) => {
+const ClosureRuleBuilder = ({ rules, goods, consumers, onAdd, onRemove }: Props) => {
   const [variable, setVariable] = useState('');
-  const [indices, setIndices] = useState('');
+  const [index, setIndex] = useState('all');
+
+  const indexOptions = () => {
+    switch (variable) {
+      case 'XS':
+      case 'P':
+        return ['all', ...goods];
+      case 'LS':
+        return ['all', ...consumers];
+      case 'W':
+        return ['all'];
+      default:
+        return ['all'];
+    }
+  };
 
   const handleAdd = () => {
     if (!variable) return;
-    const idx = indices
-      ? indices.split(',').map((s) => s.trim()).filter(Boolean)
-      : [];
+    const idx = index === 'all' ? [] : [index];
     onAdd({ variable, indices: idx });
     setVariable('');
-    setIndices('');
+    setIndex('all');
   };
 
   return (
@@ -26,21 +40,29 @@ const ClosureRuleBuilder = ({ rules, onAdd, onRemove }: Props) => {
       <div className="flex gap-2 items-center">
         <select
           value={variable}
-          onChange={(e) => setVariable(e.target.value)}
+          onChange={(e) => {
+            setVariable(e.target.value);
+            setIndex('all');
+          }}
           className="border p-1"
         >
           <option value="">Select variable</option>
+          <option value="XS">XS (supply)</option>
           <option value="P">P (price)</option>
           <option value="W">W (wage)</option>
           <option value="LS">LS (labor supply)</option>
         </select>
-        <input
-          type="text"
-          value={indices}
-          onChange={(e) => setIndices(e.target.value)}
-          placeholder="Indices (comma separated)"
+        <select
+          value={index}
+          onChange={(e) => setIndex(e.target.value)}
           className="border p-1 flex-1"
-        />
+        >
+          {indexOptions().map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </select>
         <button
           type="button"
           onClick={handleAdd}
@@ -53,13 +75,13 @@ const ClosureRuleBuilder = ({ rules, onAdd, onRemove }: Props) => {
         {rules.map((r, i) => (
           <li key={i} className="flex justify-between items-center border-b py-1">
             <span>
-              {r.variable}[{r.indices.join(',') || 'all'}]
+              Fix {r.variable}[{r.indices[0] || 'all'}] = benchmark
             </span>
             <button
               onClick={() => onRemove(i)}
               className="text-red-500"
             >
-              Remove
+              ✖
             </button>
           </li>
         ))}

--- a/frontend/src/components/ShockBuilder.tsx
+++ b/frontend/src/components/ShockBuilder.tsx
@@ -3,23 +3,36 @@ import { Shock } from '../utils/types';
 
 interface Props {
   shocks: Shock[];
+  goods: string[];
+  consumers: string[];
   onAdd: (shock: Shock) => void;
   onRemove: (index: number) => void;
 }
 
-const ShockBuilder = ({ shocks, onAdd, onRemove }: Props) => {
+const ShockBuilder = ({ shocks, goods, consumers, onAdd, onRemove }: Props) => {
   const [target, setTarget] = useState('');
-  const [indices, setIndices] = useState('');
+  const [index, setIndex] = useState('all');
   const [multiplier, setMultiplier] = useState(1);
+
+  const indexOptions = () => {
+    switch (target) {
+      case 'P':
+      case 'D':
+      case 'XS':
+        return ['all', ...goods];
+      case 'LS':
+        return ['all', ...consumers];
+      default:
+        return ['all'];
+    }
+  };
 
   const handleAdd = () => {
     if (!target) return;
-    const idx = indices
-      ? indices.split(',').map((s) => s.trim()).filter(Boolean)
-      : [];
+    const idx = index === 'all' ? [] : [index];
     onAdd({ target, indices: idx, multiplier: Number(multiplier) });
     setTarget('');
-    setIndices('');
+    setIndex('all');
     setMultiplier(1);
   };
 
@@ -28,21 +41,29 @@ const ShockBuilder = ({ shocks, onAdd, onRemove }: Props) => {
       <div className="flex gap-2 items-center">
         <select
           value={target}
-          onChange={(e) => setTarget(e.target.value)}
+          onChange={(e) => {
+            setTarget(e.target.value);
+            setIndex('all');
+          }}
           className="border p-1"
         >
           <option value="">Select target</option>
-          <option value="A">A (productivity)</option>
-          <option value="BETA">BETA (consumption)</option>
+          <option value="P">P (price)</option>
+          <option value="D">D (demand)</option>
+          <option value="XS">XS (supply)</option>
           <option value="LS">LS (labor supply)</option>
         </select>
-        <input
-          type="text"
-          value={indices}
-          onChange={(e) => setIndices(e.target.value)}
-          placeholder="Indices (comma separated)"
-          className="border p-1 flex-1"
-        />
+        <select
+          value={index}
+          onChange={(e) => setIndex(e.target.value)}
+          className="border p-1"
+        >
+          {indexOptions().map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </select>
         <input
           type="number"
           step="0.01"
@@ -59,22 +80,26 @@ const ShockBuilder = ({ shocks, onAdd, onRemove }: Props) => {
         </button>
       </div>
       <ul className="mt-2">
-        {shocks.map((s, i) => (
-          <li key={i} className="flex justify-between items-center border-b py-1">
-            <span>
-              {s.target}[{s.indices.join(',') || 'all'}] × {s.multiplier}
-            </span>
-            <button
-              onClick={() => onRemove(i)}
-              className="text-red-500"
-            >
-              Remove
-            </button>
-          </li>
-        ))}
+        {shocks.map((s, i) => {
+          const percent = ((s.multiplier - 1) * 100).toFixed(0);
+          return (
+            <li key={i} className="flex justify-between items-center border-b py-1">
+              <span>
+                Apply {percent}% change to {s.target}[{s.indices[0] || 'all'}]
+              </span>
+              <button
+                onClick={() => onRemove(i)}
+                className="text-red-500"
+              >
+                ✖
+              </button>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );
 };
 
 export default ShockBuilder;
+

--- a/frontend/src/screens/ProjectBuilderPage.tsx
+++ b/frontend/src/screens/ProjectBuilderPage.tsx
@@ -2,8 +2,12 @@ import { useParams } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import FileUploader from '../components/FileUploader';
 import SAMTable from '../components/SAMTable';
+import ClosureRuleBuilder from '../components/ClosureRuleBuilder';
+import ShockBuilder from '../components/ShockBuilder';
 import { exportSamToCsv, exportSamToExcel } from '../utils/samUtils';
-import { SAM } from '../utils/types';
+import { SAM, ClosureRule, Shock, ModelParameters } from '../utils/types';
+import { solveModel } from '../utils/api';
+import ExcelJS from 'exceljs';
 
 const factorNames = ['LAB', 'CAP'];
 
@@ -18,6 +22,20 @@ const ProjectBuilderPage = () => {
   const [useSamNames, setUseSamNames] = useState(true);
   const [samSectionOpen, setSamSectionOpen] = useState(true);
   const [benchmarkSectionOpen, setBenchmarkSectionOpen] = useState(true);
+  const [calibrationSectionOpen, setCalibrationSectionOpen] = useState(true);
+  const [closureSectionOpen, setClosureSectionOpen] = useState(true);
+  const [shockSectionOpen, setShockSectionOpen] = useState(true);
+  const [solveSectionOpen, setSolveSectionOpen] = useState(true);
+  const [calibrationMode, setCalibrationMode] = useState<'auto' | 'manual'>('auto');
+  const [betaMatrix, setBetaMatrix] = useState<number[][]>([]);
+  const [alphaParams, setAlphaParams] = useState<number[]>([]);
+  const [techParams, setTechParams] = useState<number[]>([]);
+  const [closureRules, setClosureRules] = useState<ClosureRule[]>([]);
+  const [shocks, setShocks] = useState<Shock[]>([]);
+  const [report, setReport] = useState<
+    { name: string; benchmark: number; solution: number; change: number }[] | null
+  >(null);
+  const [solving, setSolving] = useState(false);
   const createEmptySam = (goods: string[], factors: string[], households: string[]): SAM => {
     const entries = [...goods, ...factors, ...households];
     const size = entries.length;
@@ -113,6 +131,26 @@ const ProjectBuilderPage = () => {
     setGoodsPrices((prev) => adjustPriceLength(prev, industries));
   }, [industries]);
 
+  const adjustParamArray = (arr: number[], len: number, def: number) => {
+    const copy = [...arr];
+    if (copy.length < len) {
+      for (let i = copy.length; i < len; i++) copy.push(def);
+    } else if (copy.length > len) {
+      copy.length = len;
+    }
+    return copy;
+  };
+
+  useEffect(() => {
+    setAlphaParams((prev) => adjustParamArray(prev, industries, 1));
+    setTechParams((prev) => adjustParamArray(prev, industries, 1));
+    setBetaMatrix((prev) =>
+      Array.from({ length: consumers }, (_, i) =>
+        Array.from({ length: industries }, (_, j) => prev[i]?.[j] ?? 0.5)
+      )
+    );
+  }, [industries, consumers]);
+
   const handleDownloadCsv = () => {
     const csv = exportSamToCsv(sam);
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
@@ -138,6 +176,96 @@ const ProjectBuilderPage = () => {
     URL.revokeObjectURL(url);
   };
 
+  const normalizeBetaRows = () => {
+    setBetaMatrix((prev) =>
+      prev.map((row) => {
+        const sum = row.reduce((a, b) => a + b, 0);
+        return sum ? row.map((v) => v / sum) : row;
+      })
+    );
+  };
+
+  const handleSolve = async () => {
+    setSolving(true);
+    setReport(null);
+    const params: ModelParameters = {
+      prices: goodsPrices,
+      wage: wageRate,
+      beta: betaMatrix.flat(),
+      A: techParams,
+      closureRules,
+      shocks,
+      calibration: calibrationMode,
+    };
+    try {
+      const res = await solveModel('mn1', params, sam);
+      const table: { name: string; benchmark: number; solution: number; change: number }[] = [];
+      if (res.production) {
+        Object.entries(res.production).forEach(([k, v]) => {
+          const bench = 1;
+          const change = bench ? ((v - bench) / bench) * 100 : 0;
+          table.push({ name: `XS[${k}]`, benchmark: bench, solution: v, change });
+        });
+      }
+      if (res.prices) {
+        Object.entries(res.prices).forEach(([k, v]) => {
+          const idx = goodsNames.indexOf(k);
+          const bench = goodsPrices[idx] ?? 0;
+          const change = bench ? ((v - bench) / bench) * 100 : 0;
+          table.push({ name: `P[${k}]`, benchmark: bench, solution: v, change });
+        });
+      }
+      if (typeof res.utility === 'number') {
+        const bench = 1;
+        const v = res.utility;
+        const change = ((v - bench) / bench) * 100;
+        table.push({ name: 'U', benchmark: bench, solution: v, change });
+      }
+      setReport(table);
+    } catch (err) {
+      console.error(err);
+    }
+    setSolving(false);
+  };
+
+  const handleDownloadReportCsv = () => {
+    if (!report) return;
+    const header = 'Variable,Benchmark,Solution,% Change';
+    const rows = report.map(
+      (r) => `${r.name},${r.benchmark},${r.solution},${r.change}`
+    );
+    const csv = [header, ...rows].join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', 'report.csv');
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  const handleDownloadReportExcel = async () => {
+    if (!report) return;
+    const wb = new ExcelJS.Workbook();
+    const ws = wb.addWorksheet('Report');
+    ws.addRow(['Variable', 'Benchmark', 'Solution', '% Change']);
+    report.forEach((r) => ws.addRow([r.name, r.benchmark, r.solution, r.change]));
+    const buffer = await wb.xlsx.writeBuffer();
+    const blob = new Blob([buffer], {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', 'report.xlsx');
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <div
       className="max-w-2xl mx-auto my-12 p-4 space-y-8"
@@ -152,7 +280,7 @@ const ProjectBuilderPage = () => {
         </p>
       </div>
 
-      <section>
+      <section className={solving ? 'opacity-50 pointer-events-none' : ''}>
         <div
           className="flex items-center mb-4 cursor-pointer text-[#2F3A4A]"
           onClick={() => setSamSectionOpen(!samSectionOpen)}
@@ -280,7 +408,7 @@ const ProjectBuilderPage = () => {
         </div>
       </section>
 
-      <section>
+      <section className={solving ? 'opacity-50 pointer-events-none' : ''}>
         <div
           className="flex items-center mb-4 cursor-pointer text-[#2F3A4A]"
           onClick={() => setBenchmarkSectionOpen(!benchmarkSectionOpen)}
@@ -351,6 +479,242 @@ const ProjectBuilderPage = () => {
               The wage rate represents the price of labor. Default = 1.0
             </p>
           </div>
+        </div>
+      </section>
+
+      <section className={solving ? 'opacity-50 pointer-events-none' : ''}>
+        <div
+          className="flex items-center mb-4 cursor-pointer text-[#2F3A4A]"
+          onClick={() => setCalibrationSectionOpen(!calibrationSectionOpen)}
+        >
+          <span className="mr-2">{calibrationSectionOpen ? '▼' : '►'}</span>
+          <h2 className="text-xl font-semibold">4. Auto-Calibration Option</h2>
+        </div>
+        <div
+          className={`bg-white rounded-lg shadow-md space-y-6 overflow-hidden transition-all duration-300 ${calibrationSectionOpen ? 'max-h-[5000px] p-6' : 'max-h-0 p-0'}`}
+        >
+          <div>
+            <label className="block mb-2 font-medium">Calibration Mode:</label>
+            <div className="flex gap-4">
+              <label className="inline-flex items-center">
+                <input
+                  type="radio"
+                  checked={calibrationMode === 'auto'}
+                  onChange={() => setCalibrationMode('auto')}
+                  className="mr-2"
+                />
+                <span>Auto-calibrate (recommended)</span>
+              </label>
+              <label className="inline-flex items-center">
+                <input
+                  type="radio"
+                  checked={calibrationMode === 'manual'}
+                  onChange={() => setCalibrationMode('manual')}
+                  className="mr-2"
+                />
+                <span>Manual input</span>
+              </label>
+            </div>
+          </div>
+          {calibrationMode === 'manual' && (
+            <div className="space-y-6">
+              <div>
+                <h3 className="font-medium mb-2">A. Utility Parameters (BETA)</h3>
+                <table className="w-full text-left">
+                  <thead>
+                    <tr>
+                      <th className="pb-2">Consumer \ Industry</th>
+                      {goodsNames.map((g) => (
+                        <th key={g} className="pb-2">
+                          {g}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {consumerNames.map((c, i) => (
+                      <tr key={c} className="align-top">
+                        <td className="py-2 pr-4">{c}</td>
+                        {goodsNames.map((g, j) => (
+                          <td key={g} className="py-2">
+                            <input
+                              type="number"
+                              step="any"
+                              className="input w-full"
+                              value={betaMatrix[i]?.[j] ?? 0}
+                              onChange={(e) => {
+                                const val = parseFloat(e.target.value);
+                                setBetaMatrix((prev) => {
+                                  const copy = prev.map((row) => [...row]);
+                                  copy[i][j] = isNaN(val) ? 0 : val;
+                                  return copy;
+                                });
+                              }}
+                            />
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+                <p className="mt-1 text-xs text-gray-500">
+                  Each row (consumer) must sum to 1.0
+                </p>
+                <button
+                  type="button"
+                  onClick={normalizeBetaRows}
+                  className="btn bg-white border border-midgray text-darkgray hover:bg-neutral text-sm mt-2"
+                >
+                  Normalize Rows
+                </button>
+              </div>
+              <div>
+                <h3 className="font-medium mb-2">B. Production Parameters (ALPHA)</h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  {goodsNames.map((name, idx) => (
+                    <div key={`alpha-${name}`}> 
+                      <label className="block mb-1 font-medium">{name}</label>
+                      <input
+                        type="number"
+                        step="any"
+                        className="input w-full"
+                        value={alphaParams[idx] ?? 1}
+                        onChange={(e) => {
+                          const arr = [...alphaParams];
+                          arr[idx] = parseFloat(e.target.value);
+                          setAlphaParams(arr);
+                        }}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <h3 className="font-medium mb-2">C. Technology coefficient per industry (A)</h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  {goodsNames.map((name, idx) => (
+                    <div key={`tech-${name}`}>
+                      <label className="block mb-1 font-medium">{name}</label>
+                      <input
+                        type="number"
+                        step="any"
+                        className="input w-full"
+                        value={techParams[idx] ?? 1}
+                        onChange={(e) => {
+                          const arr = [...techParams];
+                          arr[idx] = parseFloat(e.target.value);
+                          setTechParams(arr);
+                        }}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section className={solving ? 'opacity-50 pointer-events-none' : ''}>
+        <div
+          className="flex items-center mb-4 cursor-pointer text-[#2F3A4A]"
+          onClick={() => setClosureSectionOpen(!closureSectionOpen)}
+        >
+          <span className="mr-2">{closureSectionOpen ? '▼' : '►'}</span>
+          <h2 className="text-xl font-semibold">5. Define Closure Rules</h2>
+        </div>
+        <div
+          className={`bg-white rounded-lg shadow-md space-y-6 overflow-hidden transition-all duration-300 ${closureSectionOpen ? 'max-h-[5000px] p-6' : 'max-h-0 p-0'}`}
+        >
+          <ClosureRuleBuilder
+            rules={closureRules}
+            goods={goodsNames}
+            consumers={consumerNames}
+            onAdd={(r) => setClosureRules([...closureRules, r])}
+            onRemove={(i) =>
+              setClosureRules(closureRules.filter((_, idx) => idx !== i))
+            }
+          />
+        </div>
+      </section>
+
+      <section className={solving ? 'opacity-50 pointer-events-none' : ''}>
+        <div
+          className="flex items-center mb-4 cursor-pointer text-[#2F3A4A]"
+          onClick={() => setShockSectionOpen(!shockSectionOpen)}
+        >
+          <span className="mr-2">{shockSectionOpen ? '▼' : '►'}</span>
+          <h2 className="text-xl font-semibold">6. Apply Shocks</h2>
+        </div>
+        <div
+          className={`bg-white rounded-lg shadow-md space-y-6 overflow-hidden transition-all duration-300 ${shockSectionOpen ? 'max-h-[5000px] p-6' : 'max-h-0 p-0'}`}
+        >
+          <ShockBuilder
+            shocks={shocks}
+            goods={goodsNames}
+            consumers={consumerNames}
+            onAdd={(s) => setShocks([...shocks, s])}
+            onRemove={(i) => setShocks(shocks.filter((_, idx) => idx !== i))}
+          />
+        </div>
+      </section>
+
+      <section>
+        <div
+          className="flex items-center mb-4 cursor-pointer text-[#2F3A4A]"
+          onClick={() => setSolveSectionOpen(!solveSectionOpen)}
+        >
+          <span className="mr-2">{solveSectionOpen ? '▼' : '►'}</span>
+          <h2 className="text-xl font-semibold">7. Solve & Report</h2>
+        </div>
+        <div
+          className={`bg-white rounded-lg shadow-md space-y-6 overflow-hidden transition-all duration-300 ${solveSectionOpen ? 'max-h-[5000px] p-6' : 'max-h-0 p-0'}`}
+        >
+          <button
+            onClick={handleSolve}
+            disabled={solving}
+            className="btn bg-primary text-white"
+          >
+            {solving ? 'Solving your model...' : 'Solve Model'}
+          </button>
+          {report && (
+            <div className="mt-4 space-y-4">
+              <table className="w-full text-left">
+                <thead>
+                  <tr>
+                    <th className="pb-2">Variable</th>
+                    <th className="pb-2">Benchmark</th>
+                    <th className="pb-2">Solution</th>
+                    <th className="pb-2">% Change</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {report.map((r) => (
+                    <tr key={r.name} className="align-top">
+                      <td className="py-1 pr-2">{r.name}</td>
+                      <td className="py-1">{r.benchmark.toFixed(2)}</td>
+                      <td className="py-1">{r.solution.toFixed(2)}</td>
+                      <td className="py-1">{r.change.toFixed(2)}%</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              <div className="flex gap-2">
+                <button
+                  onClick={handleDownloadReportExcel}
+                  className="btn bg-white border border-midgray text-darkgray hover:bg-neutral text-sm"
+                >
+                  Download Excel
+                </button>
+                <button
+                  onClick={handleDownloadReportCsv}
+                  className="btn bg-white border border-midgray text-darkgray hover:bg-neutral text-sm"
+                >
+                  Download CSV
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- add UI section for auto-calibration with manual beta, alpha, and technology inputs
- enable defining closure rules and shocks with dropdown-based builders
- add solve & report section with basic results table and downloads

## Testing
- `npm run lint` *(fails: eslint: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@heroicons%2freact)*
- `npm run build` *(fails: tsc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1958f88a0832aa5207c8a8a63a4fc