### PR TITLE
Connect MN1 solver to backend and refine model builder UI

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -409,15 +409,18 @@ def solve_model():
                 print(stack_trace)
                 return jsonify({'error': error_message, 'trace': stack_trace}), 500
 
-        elif template_id == 'mn1-cge':
-            # Placeholder implementation for MN1 model integration
-            return jsonify({
-                'message': 'MN1 model execution placeholder',
-                'prices': params.get('prices'),
-                'wage': params.get('wage'),
-                'closureRules': params.get('closureRules', []),
-                'shocks': params.get('shocks', []),
-            })
+        elif template_id in ('mn1', 'mn1-cge'):
+            try:
+                from models.mn1_wrapper import solve_mn1
+
+                results = solve_mn1(params, sam)
+                return jsonify(results)
+            except Exception as mn1_error:
+                error_message = f"Error solving MN1 model: {mn1_error}"
+                stack_trace = traceback.format_exc()
+                print(error_message)
+                print(stack_trace)
+                return jsonify({'error': error_message, 'trace': stack_trace}), 500
 
         else:
             # For other templates (not implemented in MVP)

--- a/backend/models/mn1_wrapper.py
+++ b/backend/models/mn1_wrapper.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""Wrapper for MN1 CGE model to interface with API.
+
+This provides a simple function `solve_mn1` that accepts JSON style
+inputs from the frontend and returns results in a structured format.
+The implementation reuses the dynamic simple CGE model to provide a
+light‑weight placeholder solution until the full MN1 model is
+integrated.
+"""
+from typing import Any, Dict, List
+
+from .dynamic_splcge import dynamic_solve, extract_results
+
+
+def _default_list(length: int, value: float) -> List[float]:
+    return [value for _ in range(length)]
+
+
+def solve_mn1(params: Dict[str, Any], sam: Dict[str, Any]) -> Dict[str, Any]:
+    """Solve MN1 model using provided parameters and SAM.
+
+    Args:
+        params: Model parameters collected from the UI. Expected keys
+            include ``beta`` (list) and ``A`` (list) but defaults will be
+            supplied if they are missing.
+        sam:    SAM structure containing ``goods``, ``factors``,
+            ``households`` and ``data`` (2D list).
+
+    Returns:
+        Dictionary with benchmark vs solution values for key variables.
+    """
+    sectors: List[str] = sam.get("goods", [])
+    factors: List[str] = sam.get("factors", [])
+    households: List[str] = sam.get("households", [])
+    data = sam.get("data", [])
+
+    if not sectors or not factors or not households:
+        raise ValueError("SAM must include goods, factors and households")
+
+    # Map UI parameters to dynamic_splcge inputs
+    beta = params.get("beta") or []
+    alpha_input = beta[: len(sectors)] if beta else _default_list(len(sectors), 1.0 / max(len(sectors), 1))
+
+    A_param = params.get("A") or []
+    b_input = A_param[: len(sectors)] if A_param else _default_list(len(sectors), 1.0)
+
+    container = dynamic_solve(sectors, factors, households, data, alpha_input, b_input)
+
+    return extract_results(container)

--- a/frontend/src/components/ClosureRuleBuilder.tsx
+++ b/frontend/src/components/ClosureRuleBuilder.tsx
@@ -66,7 +66,7 @@ const ClosureRuleBuilder = ({ rules, goods, consumers, onAdd, onRemove }: Props)
         <button
           type="button"
           onClick={handleAdd}
-          className="bg-blue-500 text-white px-2 py-1"
+          className="btn btn-primary"
         >
           Add
         </button>

--- a/frontend/src/components/SAMTable.tsx
+++ b/frontend/src/components/SAMTable.tsx
@@ -128,7 +128,6 @@ const SAMTable = ({ sam, onChange, readOnly = false }: SAMTableProps) => {
       // Refresh grid if API is available
       if (gridApi) {
         setTimeout(() => {
-          gridApi.sizeColumnsToFit();
           gridApi.refreshCells({ force: true });
         }, 0);
       }
@@ -164,7 +163,7 @@ const SAMTable = ({ sam, onChange, readOnly = false }: SAMTableProps) => {
       // Resize columns so the grid stays full width after edits
       if (gridApi) {
         setTimeout(() => {
-          gridApi.sizeColumnsToFit();
+          gridApi.refreshCells({ force: true });
         }, 0);
       }
     },
@@ -179,8 +178,6 @@ const SAMTable = ({ sam, onChange, readOnly = false }: SAMTableProps) => {
     // Use setTimeout to give the grid time to render before sizing columns
     setTimeout(() => {
       if (params.api) {
-        params.api.sizeColumnsToFit();
-
         // Force a redraw to ensure columns are displayed properly
         params.api.redrawRows();
       }
@@ -190,7 +187,7 @@ const SAMTable = ({ sam, onChange, readOnly = false }: SAMTableProps) => {
   // Ensure columns fit whenever the grid size changes
   const onGridSizeChanged = useCallback(() => {
     if (gridApi) {
-      gridApi.sizeColumnsToFit();
+      gridApi.refreshCells({ force: true });
     }
   }, [gridApi]);
 
@@ -198,7 +195,7 @@ const SAMTable = ({ sam, onChange, readOnly = false }: SAMTableProps) => {
   useEffect(() => {
     if (gridApi) {
       setTimeout(() => {
-        gridApi.sizeColumnsToFit();
+        gridApi.refreshCells({ force: true });
       }, 0);
     }
   }, [rowData, gridApi]);
@@ -215,7 +212,7 @@ const SAMTable = ({ sam, onChange, readOnly = false }: SAMTableProps) => {
   return (
     <div className="w-full">
       <div
-        className="ag-theme-alpine w-full max-h-[60vh] border border-midgray overflow-auto"
+        className="ag-theme-alpine w-full max-h-[60vh] border border-midgray shadow-sm overflow-x-auto"
       >
         {!sam || !sam.entries || sam.entries.length === 0 ? (
           <div className="flex flex-col h-full">

--- a/frontend/src/components/ShockBuilder.tsx
+++ b/frontend/src/components/ShockBuilder.tsx
@@ -74,7 +74,7 @@ const ShockBuilder = ({ shocks, goods, consumers, onAdd, onRemove }: Props) => {
         <button
           type="button"
           onClick={handleAdd}
-          className="bg-blue-500 text-white px-2 py-1"
+          className="btn btn-primary"
         >
           Add
         </button>

--- a/frontend/src/screens/ModelBuilderPage.tsx
+++ b/frontend/src/screens/ModelBuilderPage.tsx
@@ -905,11 +905,37 @@ const ModelBuilderPage = () => {
             </button>
             <button
               onClick={handleSolveModel}
-              className="btn btn-primary"
+              className="btn btn-primary flex items-center justify-center"
               disabled={isLoading || !samConfigured || !samValid}
               title={!samValid ? samValidationMessage || 'The SAM matrix is not balanced' : undefined}
             >
-              {isLoading ? 'Solving...' : 'Solve Model'}
+              {isLoading ? (
+                <>
+                  <svg
+                    className="animate-spin -ml-1 mr-2 h-4 w-4 text-white"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    ></circle>
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8v4l3-3-3-3v4a12 12 0 00-12 12h4z"
+                    ></path>
+                  </svg>
+                  Solving...
+                </>
+              ) : (
+                'Solve Model'
+              )}
             </button>
           </div>
         </div>

--- a/frontend/src/screens/ProjectBuilderPage.tsx
+++ b/frontend/src/screens/ProjectBuilderPage.tsx
@@ -268,7 +268,7 @@ const ProjectBuilderPage = () => {
 
   return (
     <div
-      className="max-w-2xl mx-auto my-12 p-4 space-y-8"
+      className="w-full max-w-6xl mx-auto my-12 p-4 space-y-8"
       data-project-id={projectId}
     >
       <div className="bg-[#2F3A4A] text-white rounded-lg p-6 text-center shadow-lg">
@@ -673,9 +673,35 @@ const ProjectBuilderPage = () => {
           <button
             onClick={handleSolve}
             disabled={solving}
-            className="btn bg-primary text-white"
+            className="btn btn-primary flex items-center justify-center"
           >
-            {solving ? 'Solving your model...' : 'Solve Model'}
+            {solving ? (
+              <>
+                <svg
+                  className="animate-spin -ml-1 mr-2 h-4 w-4 text-white"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  ></circle>
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8v4l3-3-3-3v4a12 12 0 00-12 12h4z"
+                  ></path>
+                </svg>
+                Solving your model...
+              </>
+            ) : (
+              'Solve Model'
+            )}
           </button>
           {report && (
             <div className="mt-4 space-y-4">


### PR DESCRIPTION
## Summary
- integrate provisional MN1 solver and expose via existing `/solve-model` API route
- widen builder layout and improve SAM editor usability
- add spinners and theme-aware buttons for solving and rule/shock management

## Testing
- `python -m py_compile backend/app.py backend/models/mn1_wrapper.py`
- `npm run lint --prefix frontend` *(fails: ESLint couldn't find the plugin "eslint-plugin-react")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68a19a533e30832a9232f941dfa98c9d